### PR TITLE
feat ai 서버와 연동 및 통합 테스트

### DIFF
--- a/booquest-api/build.gradle
+++ b/booquest-api/build.gradle
@@ -17,6 +17,21 @@ configurations {
 	compileOnly {
 		extendsFrom annotationProcessor
 	}
+
+	testRuntimeClasspath
+}
+
+tasks.test {
+	jvmArgs '-XX:+EnableDynamicAgentLoading'
+
+	doFirst {
+		def agent = configurations.testRuntimeClasspath
+				.resolve()
+				.find { it.name.startsWith('byte-buddy-agent') && it.name.endsWith('.jar') }
+		if (agent != null) {
+			jvmArgs "-javaagent:${agent.absolutePath}"
+		}
+	}
 }
 
 repositories {
@@ -31,6 +46,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	//flyway

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/ai/AiRequestConstroller.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/ai/AiRequestConstroller.java
@@ -1,0 +1,34 @@
+package com.booquest.booquest_api.adapter.in.ai;
+
+import com.booquest.booquest_api.application.port.in.ai.AiInputPort;
+import com.booquest.booquest_api.domain.model.ai.AiTaskRequest;
+import com.booquest.booquest_api.domain.model.ai.GeneratedTask;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Validated
+@RestController
+@RequestMapping("/api/ai")
+public class AiRequestConstroller {
+
+    /** 클라이언트가 보내는 요청 바디 */
+    private record GenerateTasksRequest(String userId, @NotBlank String context) {}
+    /** 클라이언트로 내려보낼 응답 바디 */
+    private record GenerateTasksResponse(List<GeneratedTask> tasks) {}
+
+    private final AiInputPort service;
+
+    @PostMapping("/generate-tasks")
+    public GenerateTasksResponse generate(@RequestBody GenerateTasksRequest req) {
+        List<GeneratedTask> tasks = service.generate(new AiTaskRequest(req.userId(), req.context()));
+        return new GenerateTasksResponse(tasks);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/ai/AiClient.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/ai/AiClient.java
@@ -1,0 +1,80 @@
+package com.booquest.booquest_api.adapter.out.ai;
+
+import com.booquest.booquest_api.adapter.out.ai.dto.AiUserProfileDtos;
+import com.booquest.booquest_api.application.port.out.ai.AiClientPort;
+import com.booquest.booquest_api.domain.model.ai.AiTaskRequest;
+import com.booquest.booquest_api.domain.model.ai.GeneratedTask;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.List;
+import static java.util.stream.Collectors.toList;
+
+@RequiredArgsConstructor
+@Component
+public class AiClient implements AiClientPort {
+
+    private final @Qualifier("aiWebClient") WebClient aiTaskWebClient;
+
+    @Override
+    public List<GeneratedTask> requestTasks(AiTaskRequest request) {
+        AiUserProfileDtos.Request body = AiUserProfileDtos.Request.builder()
+                .personality("INTJ")
+                .selectedSideHustle("블로그 운영")
+                .characteristics(List.of("분석적", "독립적"))
+                .hobbies(List.of("독서", "등산"))
+                .skills(List.of("Python", "FastAPI"))
+                .experienceLevel("중급")
+                .build();
+
+        AiUserProfileDtos.Response resp = aiTaskWebClient.post()
+                // FastAPI 라우터가 "/ai" prefix를 사용함
+                .uri("/ai/generate-tasks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(AiUserProfileDtos.Response.class)
+                .block();
+
+        if (resp == null) {
+            throw new IllegalStateException("AI server returned null response");
+        }
+        if (!resp.isSuccess()) {
+            throw new IllegalStateException("AI server failed: " + resp.getMessage());
+        }
+        if (resp.getBigTasks() == null || resp.getBigTasks().isEmpty()) {
+            throw new IllegalStateException("AI server returned empty big_tasks");
+        }
+
+        return resp.getBigTasks().stream()
+                .map(task -> new GeneratedTask(
+                        asString(firstNonNull(task.get("title"), task.get("name"))),        // title/name 호환
+                        asString(firstNonNull(task.get("description"), task.get("desc"))),  // description/desc 호환
+                        toInteger(firstNonNull(task.get("priority"), task.get("prio"))),    // priority/prio 호환
+                        asString(firstNonNull(task.get("difficulty"), task.get("level")))   // difficulty/level 호환
+                ))
+                .collect(toList());
+    }
+
+
+    /* ---- 유틸 ---- */
+    private static Object firstNonNull(Object a, Object b) { return a != null ? a : b; }
+
+    private static String asString(Object v) {
+        return v == null ? null : String.valueOf(v);
+    }
+
+    private static Integer toInteger(Object v) {
+        if (v == null) return null;
+        if (v instanceof Integer i) return i;
+        if (v instanceof Long l) return Math.toIntExact(l);
+        if (v instanceof Double d) return d.intValue();
+        if (v instanceof Float f) return f.intValue();
+        var s = v.toString().trim();
+        try { return Integer.parseInt(s); } catch (NumberFormatException ignore) { return null; }
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/ai/dto/AiUserProfileDtos.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/ai/dto/AiUserProfileDtos.java
@@ -1,0 +1,61 @@
+package com.booquest.booquest_api.adapter.out.ai.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * FastAPI의 UserProfileRequest(JSON)와 1:1 매핑되는 Java DTO.
+ * - FastAPI는 snake_case 키를 사용하므로 @JsonProperty로 정확히 매핑
+ * - 유효성 검사를 위해 jakarta.validation 어노테이션 추가(선택)
+ */
+public class AiUserProfileDtos {
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Request {
+        @NotBlank
+        private String personality;
+
+        @JsonProperty("selected_side_hustle")
+        @NotBlank
+        private String selectedSideHustle;
+
+        @NotEmpty @Size(min = 1)
+        private List<String> characteristics;
+
+        @NotEmpty @Size(min = 1)
+        private List<String> hobbies;
+
+        @NotEmpty @Size(min = 1)
+        private List<String> skills;
+
+        @JsonProperty("experience_level")
+        @NotBlank
+        private String experienceLevel;
+    }
+
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        private boolean success;
+
+        @JsonProperty("big_tasks")
+        private List<Map<String, Object>> bigTasks;
+
+        private String message;
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/ai/AiInputPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/ai/AiInputPort.java
@@ -1,0 +1,14 @@
+package com.booquest.booquest_api.application.port.in.ai;
+
+import com.booquest.booquest_api.domain.model.ai.AiTaskRequest;
+import com.booquest.booquest_api.domain.model.ai.GeneratedTask;
+
+import java.util.List;
+
+/**
+ * 애플리케이션 계층에서 AI 태스크 생성을 위한 입력 포트.
+ * Controller -> Service 의 진입점 역할을 합니다.
+ */
+public interface AiInputPort {
+    List<GeneratedTask> generate(AiTaskRequest request);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/ai/AiClientPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/ai/AiClientPort.java
@@ -1,0 +1,11 @@
+package com.booquest.booquest_api.application.port.out.ai;
+
+import com.booquest.booquest_api.domain.model.ai.AiTaskRequest;
+import com.booquest.booquest_api.domain.model.ai.GeneratedTask;
+
+import java.util.List;
+
+/** AI 서버 호출 어댑터가 구현해야 하는 출력 포트 */
+public interface AiClientPort {
+    List<GeneratedTask> requestTasks(AiTaskRequest request);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/ai/AIAssitantService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/ai/AIAssitantService.java
@@ -1,0 +1,23 @@
+package com.booquest.booquest_api.application.service.ai;
+
+import com.booquest.booquest_api.application.port.in.ai.AiInputPort;
+import com.booquest.booquest_api.application.port.out.ai.AiClientPort;
+import com.booquest.booquest_api.domain.model.ai.AiTaskRequest;
+import com.booquest.booquest_api.domain.model.ai.GeneratedTask;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AIAssitantService implements AiInputPort {
+
+    private final AiClientPort aiTaskClient;
+
+    @Override
+    public List<GeneratedTask> generate(AiTaskRequest request) {
+
+        return aiTaskClient.requestTasks(request);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/config/JpaAuditingConfig.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/config/JpaAuditingConfig.java
@@ -1,9 +1,11 @@
 package com.booquest.booquest_api.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
+@Profile("!ai_test")   // ai_test일 땐 Auditing 비활성
 @EnableJpaAuditing
 public class JpaAuditingConfig {
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/config/PropertyConfig.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/config/PropertyConfig.java
@@ -2,13 +2,8 @@ package com.booquest.booquest_api.config;
 
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.PropertySource;
-import org.springframework.context.annotation.PropertySources;
 
 @Configuration
-@PropertySources({
-        @PropertySource("classpath:properties/env.properties")
-})
 public class PropertyConfig {
 
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/config/WebClientConfig.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/config/WebClientConfig.java
@@ -1,0 +1,17 @@
+package com.booquest.booquest_api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean(name = "aiWebClient")
+    public WebClient aiTaskWebClient(@Value("${ai.base-url:http://localhost:8000}") String baseUrl) {
+        return WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/model/ai/AiTaskRequest.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/model/ai/AiTaskRequest.java
@@ -1,0 +1,17 @@
+package com.booquest.booquest_api.domain.model.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * AI 태스크 생성 요청 모델.
+ * userId는 선택적, context는 필수입니다.
+ */
+@Getter
+@AllArgsConstructor
+public class AiTaskRequest {
+    private final String userId;
+    @NonNull
+    private final String context;
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/model/ai/GeneratedTask.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/model/ai/GeneratedTask.java
@@ -1,0 +1,17 @@
+package com.booquest.booquest_api.domain.model.ai;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * AI 서버가 생성해 준 태스크 도메인 모델.
+ * priority는 숫자/문자 등 다양한 타입이 섞일 수 있어 Object로 둡니다.
+ */
+@Data
+@AllArgsConstructor
+public class GeneratedTask {
+    private String title;
+    private String description;
+    private Object priority;
+    private String difficulty;
+}

--- a/booquest-api/src/main/resources/application-ai_test.yml
+++ b/booquest-api/src/main/resources/application-ai_test.yml
@@ -1,0 +1,24 @@
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      - org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
+      - org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration
+  flyway:
+    enabled: false
+  datasource:
+    url: ""                # 상속/머지 방지
+    driver-class-name: ""
+    username: ""
+    password: ""
+  data:
+    jpa:
+      repositories:
+        enabled: false     # (보강) 리포지토리도 비활성화
+
+logging:
+  level:
+    org.hibernate: WARN
+
+ai:
+  base-url: http://localhost:8000

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -22,8 +22,18 @@ spring:
     baseline-on-migrate: true
     locations: classpath:db/migration
 
+  # (선택) 외부 프로퍼티 파일을 '있으면' 불러오기
+  # 기존 @PropertySource 대체 — 파일 없으면 무시하므로 부팅 실패 없음
+  config:
+    import: optional:classpath:properties/env.properties
+
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
+
+# --- AI 서버 설정 ---
+ai:
+  base-url: ${AI_BASE_URL:http://localhost:8000}
+  timeout-ms: ${AI_TIMEOUT_MS:5000}
 
 logging:
   level:

--- a/booquest-api/src/test/java/com/booquest/booquest_api/ai/AiFlowIntegrationTest.java
+++ b/booquest-api/src/test/java/com/booquest/booquest_api/ai/AiFlowIntegrationTest.java
@@ -1,0 +1,112 @@
+package com.booquest.booquest_api.ai;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 진짜 FastAPI까지 때리고 오는 E2E.
+ * - 사전조건: uvicorn으로 AI 서버가 {AI_SERVER_PORT} 포트에서 실행 중일 것 (기본 8000)
+ * - 프로필: ai_test (DB/JPA 비활성)
+ *
+ * 안전장치:
+ * - 서버가 죽어있으면 테스트를 "실패" 대신 "스킵" 처리(Assume)하여 CI를 흔들지 않음.
+ */
+@SpringBootTest(
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+		properties = {
+				// DB/JPA 관련 자동구성 전부 비활성화
+				"spring.autoconfigure.exclude=" +
+						"org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.data.jpa.JpaRepositoriesAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration," +
+						"org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration" +
+						// (부트 3.2+ 사용 중이면 ↓ 이것도 같이 끄면 깔끔)
+						",org.springframework.boot.autoconfigure.jdbc.JdbcClientAutoConfiguration"
+		}
+)
+@ActiveProfiles("ai_test")
+class AiFlowE2eRealServerTest {
+	@LocalServerPort
+	int port;
+
+	@Autowired TestRestTemplate rest;
+
+	static final ObjectMapper om = new ObjectMapper();
+
+	// 외부 FastAPI 서버 포트 — 필요 시 환경변수/시스템프로퍼티로 바인딩해도 좋음
+	static final int AI_SERVER_PORT = 8000; // uvicorn 기본 예시
+	static final String AI_BASE = "http://127.0.0.1:" + AI_SERVER_PORT;
+
+	/** 빠르게 살아있는지 체크해서 아니면 테스트 스킵 */
+	static boolean ping(String url) {
+		try {
+			var u = new URL(url);
+			var conn = (HttpURLConnection) u.openConnection();
+			conn.setConnectTimeout(1000);
+			conn.setReadTimeout(1000);
+			conn.setRequestMethod("GET");
+			conn.connect();
+			// /docs 는 200이면 좋고, /ai/generate-tasks는 POST 전용이라 405여도 "살아있음"으로 간주
+			return conn.getResponseCode() < 500;
+		} catch (IOException e) {
+			return false;
+		}
+	}
+
+	@BeforeEach
+	void assumeAiServerUp() {
+		boolean up = ping(AI_BASE + "/docs");
+		Assumptions.assumeTrue(
+				up,
+				() -> "AI 서버가 " + AI_BASE + " 에서 실행 중이어야 합니다 (예: uvicorn app.main:app --port " + AI_SERVER_PORT + ")."
+		);
+	}
+
+	@Test
+	@DisplayName("실제 AI 서버로 /ai/generate-tasks 호출 → 백엔드가 그대로 변환하여 반환")
+	void endToEnd_real_ai_ok() throws Exception {
+		var req = Map.of(
+				"userId", "u1",
+				"context", "SNS 부업 초기 큰 임무 5개를 단계별로 만들어줘"
+		);
+
+		// 여기서는 스프링 백엔드의 랜덤 포트로 호출한다.
+		var resp = rest.postForEntity(
+				"http://localhost:" + port + "/api/ai/generate-tasks",
+				req,
+				String.class
+		);
+
+		Assertions.assertThat(resp.getStatusCode().is2xxSuccessful())
+				.as("백엔드 응답 HTTP 2xx 여야 함").isTrue();
+
+		Map<String, Object> body = om.readValue(resp.getBody(), new TypeReference<>() {});
+		Assertions.assertThat(body).containsKey("tasks");
+
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> tasks = (List<Map<String, Object>>) body.get("tasks");
+
+		Assertions.assertThat(tasks)
+				.as("AI가 big_tasks를 생성해야 함")
+				.isNotNull()
+				.isNotEmpty();
+
+		Map<String, Object> t0 = tasks.get(0);
+		Assertions.assertThat(t0).containsKeys("title", "description");
+	}
+}


### PR DESCRIPTION
📌 PR 제목
[Feature] AI 연동 및 테스트 케이스 개발

✅ 작업 내용
ai_test 프로필 추가 및 환경 설정(application.ai_test.yml) 구성

AI 서버 연동 로직 구현

실제 AI 서버 호출 기반 E2E 테스트(AiFlowE2eRealServerTest) 작성

JPA 빈 초기화 문제 해결 및 테스트 환경 구성

Mockito/ByteBuddy 기반 외부 연동 모킹 환경 추가

🔍 관련 이슈
Resolved: #이슈번호

💡 추가 설명
테스트 실행 시 -Dspring.profiles.active=ai_test 지정 필요

AI 서버가 로컬 또는 테스트 환경에서 실행 중이어야 함

실제 호출 예시:

json
POST /ai/generate-tasks
{
  "userId": 1,
  "mbti": "INTJ",
  "age": 30,
  "gender": "male",
  "personality": "논리적이며 계획적",
  "goals": ["부업 아이템 찾기", "온라인 판매 시작"]
}
📸 스크린샷
(해당 사항 없음)

📋 체크리스트
 코드가 정상 동작함

 테스트를 모두 통과함

 문서/주석이 적절히 작성됨

 Self Review 완료함