### PR TITLE
[Feature] 로그인한 사용자의 부업 목록 조회 API, 사용자의 부업 조회 API 구현

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/sidejob/SideJobController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/sidejob/SideJobController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/sideJob")
-@Tag(name = "Side Job", description = "부업 API")
+@Tag(name = "Side Job Recommendation", description = "부업 추천 API")
 public class SideJobController {
 
     private final RegenerateSideJobUseCase regenerateSideJobUseCase;

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/UserSideJobController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/UserSideJobController.java
@@ -1,0 +1,60 @@
+package com.booquest.booquest_api.adapter.in.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobListResponse;
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobResponse;
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobSummaryResponse;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobListUseCase;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobSummaryUseCase;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobUseCase;
+import com.booquest.booquest_api.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user/sideJob")
+@Tag(name = "User Side Job", description = "사용자의 부업 API")
+public class UserSideJobController {
+    private final GetUserSideJobListUseCase getSideJobListUserCase;
+    private final GetUserSideJobUseCase getSideJobUserCase;
+    private final GetUserSideJobSummaryUseCase getUserSideJobSummaryUseCase;
+
+    @GetMapping
+    @Operation(summary = "부업 목록 조회", description = "로그인한 사용자의 부업 목록을 조회합니다.")
+    public ApiResponse<List<UserSideJobListResponse>> getUserSideJobList() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(auth.getName());
+
+        List<UserSideJobListResponse> response = getSideJobListUserCase.getUserSideJobList(userId);
+        return ApiResponse.success("부업 목록을 조회하였습니다.", response);
+    }
+
+    @GetMapping("/{userSideJobId}")
+    @Operation(summary = "부업 조회", description = "로그인한 사용자의 부업을 조회합니다.")
+    public ApiResponse<UserSideJobResponse> getUserSideJob(@PathVariable Long userSideJobId) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(auth.getName());
+
+        UserSideJobResponse response = getSideJobUserCase.getUserSideJob(userId, userSideJobId);
+        return ApiResponse.success("부업을 조회하였습니다.", response);
+    }
+
+//    @GetMapping("/{userSideJobId}/summary")
+//    @Operation(summary = "부업 요약 조회", description = "로그인한 사용자의 부업 요약을 조회합니다.")
+//    public ApiResponse<UserSideJobSummaryResponse> getUserSideJobSummary(@PathVariable Long userSideJobId) {
+//        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+//        Long userId = Long.parseLong(auth.getName());
+//
+//        UserSideJobSummaryResponse response = getUserSideJobSummaryUseCase.getUserSideJobSummary(userId, userSideJobId);
+//        return ApiResponse.success("부업 요약을 조회하였습니다.", response);
+//    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobListResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobListResponse.java
@@ -1,0 +1,55 @@
+package com.booquest.booquest_api.adapter.in.usersidejob.dto;
+
+import com.booquest.booquest_api.domain.usersidejob.enums.UserSideJobStatus;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class UserSideJobListResponse {
+    private Long id;
+    private Long sideJobId;
+    private String title;
+    private String description;
+    private UserSideJobStatus status;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+    private String period;
+
+    private static final DateTimeFormatter D = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static UserSideJobListResponse toResponse(UserSideJob userSideJob) {
+        UserSideJobStatus status = getStatus(userSideJob);
+        String period = calculatePeriod(userSideJob.getStartedAt(), userSideJob.getEndedAt());
+
+        return UserSideJobListResponse.builder()
+                .id(userSideJob.getId())
+                .sideJobId(userSideJob.getSideJobId())
+                .title(userSideJob.getTitle())
+                .description(userSideJob.getDescription())
+                .status(status)
+                .startedAt(userSideJob.getStartedAt())
+                .endedAt(userSideJob.getEndedAt())
+                .period(period)
+                .build();
+    }
+
+    private static UserSideJobStatus getStatus(UserSideJob userSideJob) {
+        if (userSideJob.getStatus() != null) return userSideJob.getStatus();
+        if (userSideJob.getEndedAt() != null) return UserSideJobStatus.COMPLETED;
+        if (userSideJob.getStartedAt() != null) return UserSideJobStatus.IN_PROGRESS;
+        return UserSideJobStatus.PLANNED;
+    }
+
+    private static String calculatePeriod(LocalDateTime startedAt, LocalDateTime endedAt) {
+        // yyyy.MM.dd ~ yyyy.MM.dd / yyyy.MM.dd ~ 진행중 / 시작일 없으면 "-"
+        if (startedAt == null) return "-";
+        String start = D.format(startedAt);
+        if (endedAt != null)  return start + " ~ " + D.format(endedAt);
+        return start + " ~ 진행중";
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobResponse.java
@@ -1,0 +1,32 @@
+package com.booquest.booquest_api.adapter.in.usersidejob.dto;
+
+import com.booquest.booquest_api.domain.usersidejob.enums.UserSideJobStatus;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserSideJobResponse {
+    private Long id;
+    private Long sideJobId;
+    private String title;
+    private String description;
+    private UserSideJobStatus status;
+    private LocalDateTime startedAt;
+    private LocalDateTime endedAt;
+
+    public static UserSideJobResponse toResponse(UserSideJob userSideJob) {
+        return UserSideJobResponse.builder()
+                .id(userSideJob.getId())
+                .sideJobId(userSideJob.getSideJobId())
+                .title(userSideJob.getTitle())
+                .description(userSideJob.getDescription())
+                .status(userSideJob.getStatus())
+                .startedAt(userSideJob.getStartedAt())
+                .endedAt(userSideJob.getEndedAt())
+                .build();
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobSummaryResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/usersidejob/dto/UserSideJobSummaryResponse.java
@@ -1,0 +1,48 @@
+package com.booquest.booquest_api.adapter.in.usersidejob.dto;
+
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Getter
+@Builder
+public class UserSideJobSummaryResponse {
+    //부업, 기간, 카테고리, 나의 총 수익, 완료한 퀘스트 수, 첫 수익화까지(일)
+    private final UserSideJob userSideJob;
+    private final String period;                 // ex. 2025.08.01 ~ 2025.09.01 / 2025.08.01 ~ 진행중
+    private final String category;
+    private final BigDecimal totalRevenue;       // 나의 총 수익
+    private final Integer completedQuestCount;   // 완료한 퀘스트 수
+    private final Integer daysToFirstRevenue;    // 첫 수익화까지(일)
+
+    private static final DateTimeFormatter D = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    public static UserSideJobSummaryResponse toResponse(UserSideJob userSideJob,
+                                                        String category,
+                                                        BigDecimal totalRevenue,
+                                                        Integer completedQuestCount,
+                                                        Integer daysToFirstRevenue) {
+        return UserSideJobSummaryResponse.builder()
+                .userSideJob(userSideJob)
+                .period(calculatePeriod(userSideJob.getStartedAt(), userSideJob.getEndedAt()))
+                .category(category)
+                .totalRevenue(totalRevenue)
+                .completedQuestCount(completedQuestCount)
+                .daysToFirstRevenue(daysToFirstRevenue)
+                .build();
+    }
+
+    private static String calculatePeriod(LocalDateTime startedAt, LocalDateTime endedAt) {
+        // yyyy.MM.dd ~ yyyy.MM.dd / yyyy.MM.dd ~ 진행중 / 시작일 없으면 "-"
+        if (startedAt == null) return "-";
+        String start = D.format(startedAt);
+        if (endedAt != null) {
+            return start + " ~ " + D.format(endedAt);
+        }
+        return start + " ~ 진행중";
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepository.java
@@ -1,0 +1,16 @@
+package com.booquest.booquest_api.adapter.out.usersidejob.persistence;
+
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface UserSideJobRepository extends JpaRepository<UserSideJob, Long> {
+
+    List<UserSideJob> findAllByUserId(Long userId);
+
+    Optional<UserSideJob> findById(Long userSideJobId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepositoryAdapter.java
@@ -1,0 +1,26 @@
+package com.booquest.booquest_api.adapter.out.usersidejob.persistence;
+
+import com.booquest.booquest_api.application.port.out.usersidejob.UserSideJobRepositoryPort;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class UserSideJobRepositoryAdapter implements UserSideJobRepositoryPort {
+
+    private final UserSideJobRepository userSideJobRepository;
+
+    @Override
+    public List<UserSideJob> findAllByUserId(Long userId) {
+        return userSideJobRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public Optional<UserSideJob> findById(Long userSideJobId) {
+        return userSideJobRepository.findById(userSideJobId);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobListUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobListUseCase.java
@@ -1,0 +1,9 @@
+package com.booquest.booquest_api.application.port.in.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobListResponse;
+
+import java.util.List;
+
+public interface GetUserSideJobListUseCase {
+    List<UserSideJobListResponse> getUserSideJobList(Long userId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobSummaryUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobSummaryUseCase.java
@@ -1,0 +1,7 @@
+package com.booquest.booquest_api.application.port.in.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobSummaryResponse;
+
+public interface GetUserSideJobSummaryUseCase {
+    UserSideJobSummaryResponse getUserSideJobSummary(Long userId, Long userSideJobId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/usersidejob/GetUserSideJobUseCase.java
@@ -1,0 +1,7 @@
+package com.booquest.booquest_api.application.port.in.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobResponse;
+
+public interface GetUserSideJobUseCase {
+    UserSideJobResponse getUserSideJob(Long userId, Long userSideJobId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/usersidejob/UserSideJobRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/usersidejob/UserSideJobRepositoryPort.java
@@ -1,0 +1,11 @@
+package com.booquest.booquest_api.application.port.out.usersidejob;
+
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface UserSideJobRepositoryPort {
+    List<UserSideJob> findAllByUserId(Long userId);
+    Optional<UserSideJob> findById(Long userSideJobId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobListService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobListService.java
@@ -1,0 +1,25 @@
+package com.booquest.booquest_api.application.service.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobListResponse;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobListUseCase;
+import com.booquest.booquest_api.application.port.out.usersidejob.UserSideJobRepositoryPort;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserSideJobListService implements GetUserSideJobListUseCase {
+    private final UserSideJobRepositoryPort userSideJobRepositoryPort;
+
+    @Override
+    public List<UserSideJobListResponse> getUserSideJobList(Long userId) {
+        List<UserSideJob> userSideJobs =  userSideJobRepositoryPort.findAllByUserId(userId);
+
+        return userSideJobs.stream()
+                .map(UserSideJobListResponse::toResponse)
+                .toList();
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobService.java
@@ -1,0 +1,24 @@
+package com.booquest.booquest_api.application.service.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobResponse;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobUseCase;
+import com.booquest.booquest_api.application.port.out.usersidejob.UserSideJobRepositoryPort;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserSideJobService implements GetUserSideJobUseCase {
+    private final UserSideJobRepositoryPort userSideJobRepositoryPort;
+
+    @Override
+    public UserSideJobResponse getUserSideJob(Long userId, Long userSideJobId) {
+        UserSideJob userSideJob = userSideJobRepositoryPort.findById(userSideJobId)
+                .filter(e -> e.getUserId().equals(userId))
+                .orElseThrow(() -> new EntityNotFoundException("UserSideJob not found: " + userSideJobId));
+
+        return UserSideJobResponse.toResponse(userSideJob);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobSummaryService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobSummaryService.java
@@ -1,0 +1,31 @@
+package com.booquest.booquest_api.application.service.usersidejob;
+
+import com.booquest.booquest_api.adapter.in.usersidejob.dto.UserSideJobSummaryResponse;
+import com.booquest.booquest_api.application.port.in.usersidejob.GetUserSideJobSummaryUseCase;
+import com.booquest.booquest_api.application.port.out.usersidejob.UserSideJobRepositoryPort;
+import com.booquest.booquest_api.domain.usersidejob.model.UserSideJob;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserSideJobSummaryService implements GetUserSideJobSummaryUseCase {
+    private final UserSideJobRepositoryPort userSideJobRepositoryPort;
+
+    @Override
+    public UserSideJobSummaryResponse getUserSideJobSummary(Long userId, Long userSideJobId) {
+        UserSideJob userSideJob = userSideJobRepositoryPort.findById(userSideJobId)
+                .filter(e -> e.getUserId().equals(userId))
+                .orElseThrow(() -> new EntityNotFoundException("UserSideJob not found: " + userSideJobId));
+
+        String category = "";
+        BigDecimal totalRevenue = BigDecimal.ZERO;
+        int completedQuestCount = 0;
+        int daysToFirstRevenue = 0;
+
+        return UserSideJobSummaryResponse.toResponse(userSideJob, category, totalRevenue, completedQuestCount, daysToFirstRevenue);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/enums/UserSideJobStatus.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/enums/UserSideJobStatus.java
@@ -1,0 +1,5 @@
+package com.booquest.booquest_api.domain.usersidejob.enums;
+
+public enum UserSideJobStatus {
+    PLANNED, IN_PROGRESS, COMPLETED, CANCELLED
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
@@ -1,0 +1,44 @@
+package com.booquest.booquest_api.domain.usersidejob.model;
+
+import com.booquest.booquest_api.common.entity.AuditableEntity;
+import com.booquest.booquest_api.domain.usersidejob.enums.UserSideJobStatus;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_side_jobs")
+@Builder
+@Getter
+public class UserSideJob extends AuditableEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // FK 제약은 DB에만 있고, 엔티티는 값 매핑만 (히스토리 보존 목적)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "side_job_id", nullable = false)
+    private Long sideJobId;
+
+    private String title;
+
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @JdbcTypeCode(SqlTypes.NAMED_ENUM)
+    @Column(columnDefinition = "sidejob_status")
+    private UserSideJobStatus status = UserSideJobStatus.PLANNED;
+
+    @Column(name = "started_at")
+    private LocalDateTime startedAt;
+
+    @Column(name = "ended_at")
+    private LocalDateTime endedAt;
+}

--- a/booquest-api/src/main/resources/db/migration/V9__create_user_side_jobs_table.sql
+++ b/booquest-api/src/main/resources/db/migration/V9__create_user_side_jobs_table.sql
@@ -1,0 +1,27 @@
+CREATE TYPE sidejob_status AS ENUM ('PLANNED', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED');
+
+CREATE TABLE user_side_jobs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    side_job_id BIGINT NOT NULL,
+    title VARCHAR(200) NOT NULL,
+    description TEXT,
+    status sidejob_status NOT NULL DEFAULT 'PLANNED',
+    started_at TIMESTAMPTZ,
+    ended_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_side_jobs_user_id ON user_side_jobs(user_id);
+CREATE INDEX idx_user_side_jobs_started_at ON user_side_jobs(started_at);
+CREATE INDEX idx_user_side_jobs_ended_at ON user_side_jobs(ended_at);
+
+-- 조인 최적화
+CREATE INDEX IF NOT EXISTS idx_user_side_jobs_side_job_id
+  ON user_side_jobs(side_job_id);
+
+-- 기간 무결성
+ALTER TABLE user_side_jobs
+  ADD CONSTRAINT chk_usj_period
+  CHECK (ended_at IS NULL OR started_at IS NULL OR ended_at >= started_at);


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
로그인한 사용자의 부업 목록 조회 API, 부업 조회 API 구현

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 로그인한 사용자의 부업 목록 조회 API 구현
- 로그인한 사용자의 부업 조회 API 구현
- DB에 user_side_jobs 테이블 추가 (부업 추천(side_jobs)과 구분)

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [ ] 테스트를 모두 통과함
- [ ] 문서/주석이 적절히 작성됨
- [x] Self Review 완료함
