### PR TITLE
[Feat] 온보딩 데이터 upsert 수정 & OnboardingProgressInfo 유저가 선택한 부업 아이디 응답 추가

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/onboarding/web/OnboardingController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/onboarding/web/OnboardingController.java
@@ -3,7 +3,6 @@ package com.booquest.booquest_api.adapter.in.onboarding.web;
 import com.booquest.booquest_api.adapter.in.onboarding.web.dto.OnboardingDataRequest;
 import com.booquest.booquest_api.adapter.in.onboarding.web.dto.SideJobDetailResponseDto;
 import com.booquest.booquest_api.adapter.in.onboarding.web.dto.SideJobResponseDto;
-import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepResponseDto;
 import com.booquest.booquest_api.application.port.in.character.CreateCharacterUseCase;
 import com.booquest.booquest_api.application.port.in.dto.GenerateSideJobRequest;
 import com.booquest.booquest_api.application.port.in.dto.SubmitOnboardingData;
@@ -19,7 +18,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/onboarding/web/dto/OnboardingProgressInfo.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/onboarding/web/dto/OnboardingProgressInfo.java
@@ -3,5 +3,5 @@ package com.booquest.booquest_api.adapter.in.onboarding.web.dto;
 import lombok.Builder;
 
 @Builder
-public record OnboardingProgressInfo(boolean sideJobRecommended, boolean missionRecommended, boolean sideJobCreated) {
+public record OnboardingProgressInfo(boolean sideJobRecommended, boolean missionRecommended, boolean sideJobCreated, long selectedSideJobId) {
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
@@ -30,4 +30,6 @@ public interface SideJobRepository extends JpaRepository<SideJob, Long> {
     boolean existsByUserId(Long userId);
 
     List<SideJob> findAllByUserId(Long userId);
+
+    List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
@@ -32,4 +32,7 @@ public interface SideJobRepository extends JpaRepository<SideJob, Long> {
     List<SideJob> findAllByUserId(Long userId);
 
     List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Query("SELECT s.id FROM SideJob s WHERE s.userId = :userId AND s.isSelected = true")
+    Optional<Long> findSelectedSideJobByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
@@ -2,12 +2,10 @@ package com.booquest.booquest_api.adapter.out.sidejob.persistence;
 
 import com.booquest.booquest_api.application.port.out.sidejob.SideJobRepositoryPort;
 import com.booquest.booquest_api.domain.sidejob.model.SideJob;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 
 @Component
@@ -44,5 +42,10 @@ public class SideJobRepositoryAdapter implements SideJobRepositoryPort {
     @Override
     public List<SideJob> findAllByUserId(Long userId) {
         return sideJobRepository.findAllByUserId(userId);
+    }
+
+    @Override
+    public List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId) {
+        return sideJobRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
@@ -48,4 +48,10 @@ public class SideJobRepositoryAdapter implements SideJobRepositoryPort {
     public List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId) {
         return sideJobRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
     }
+
+    @Override
+    public Long findSelectedSideJobByUserId(Long userId) {
+        return sideJobRepository.findSelectedSideJobByUserId(userId)
+                .orElse(null);
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/onboarding/CheckSideJobStatusUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/onboarding/CheckSideJobStatusUseCase.java
@@ -9,11 +9,14 @@ public interface CheckSideJobStatusUseCase {
 
     boolean isSideJobCreated(Long userId); // 부업 생성 완료 여부
 
+    long getSelectedSideJobId(Long userId); // 유저가 선택한 부업
+
     default OnboardingProgressInfo getOnboardingProgress(Long userId) {
         return OnboardingProgressInfo.builder()
                 .sideJobRecommended(isSideJobRecommended(userId))
                 .missionRecommended(isMissionRecommended(userId))
                 .sideJobCreated(isSideJobCreated(userId))
+                .selectedSideJobId(getSelectedSideJobId(userId))
                 .build();
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/character/CharacterCommandPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/character/CharacterCommandPort.java
@@ -1,7 +1,10 @@
 package com.booquest.booquest_api.application.port.out.character;
 
 import com.booquest.booquest_api.domain.character.model.UserCharacter;
+import java.util.Optional;
 
 public interface CharacterCommandPort {
     UserCharacter save(UserCharacter userCharacter);
+
+    Optional<UserCharacter> findByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/onboarding/OnboardingCategoryRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/onboarding/OnboardingCategoryRepository.java
@@ -4,4 +4,5 @@ import com.booquest.booquest_api.domain.onboarding.model.OnboardingCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OnboardingCategoryRepository extends JpaRepository<OnboardingCategory, Long> {
+    void deleteByProfileId(Long profileId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
@@ -16,4 +16,6 @@ public interface SideJobRepositoryPort {
     List<SideJob> findAllByIds(List<Long> sideJobIds);
 
     List<SideJob> findAllByUserId(Long userId);
+
+    List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
@@ -18,4 +18,6 @@ public interface SideJobRepositoryPort {
     List<SideJob> findAllByUserId(Long userId);
 
     List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Long findSelectedSideJobByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/character/CharacterService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/character/CharacterService.java
@@ -9,6 +9,7 @@ import com.booquest.booquest_api.application.port.out.character.CharacterQueryPo
 import com.booquest.booquest_api.domain.character.enums.CharacterType;
 import com.booquest.booquest_api.domain.character.model.UserCharacter;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,14 +24,17 @@ public class CharacterService implements CreateCharacterUseCase, GetCharacterUse
     @Override
     @Transactional
     public void createCharacter(long userId, CharacterType type) {
-        UserCharacter character = UserCharacter.builder()
-                .userId(userId)
-                .name("부냥이")
-                .characterType(type)
-                .avatarUrl("fake-url")
-                .level(1)
-                .exp(0)
-                .build();
+        UserCharacter character = characterCommandPort.findByUserId(userId)
+                .map(existing -> existing.withCharacterType(type))
+                .orElseGet(() -> UserCharacter.builder()
+                        .userId(userId)
+                        .name("부냥이")
+                        .characterType(type)
+                        .avatarUrl("fake-url")
+                        .level(1)
+                        .exp(0)
+                        .build()
+                );
 
         characterCommandPort.save(character);
     }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/CheckSideJobStatusService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/CheckSideJobStatusService.java
@@ -14,8 +14,6 @@ public class CheckSideJobStatusService implements CheckSideJobStatusUseCase {
     private final SideJobRepositoryPort sideJobRepositoryPort;
     private final MissionRepositoryPort missionRepositoryPort;
 
-
-
     @Override
     public boolean isSideJobRecommended(Long userId) {
         return sideJobRepositoryPort.isExistByUserId(userId);
@@ -31,5 +29,10 @@ public class CheckSideJobStatusService implements CheckSideJobStatusUseCase {
         return missionRepositoryPort.existsByUserIdAndStatusNot(
                 userId, MissionStatus.PLANNED
         );
+    }
+
+    @Override
+    public long getSelectedSideJobId(Long userId) {
+        return sideJobRepositoryPort.findSelectedSideJobByUserId(userId);
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/SelectSideJobService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/SelectSideJobService.java
@@ -1,10 +1,7 @@
 package com.booquest.booquest_api.application.service.sidejob;
 
 import com.booquest.booquest_api.application.port.in.sidejob.SelectSideJobUseCase;
-import com.booquest.booquest_api.application.port.in.mission.SelectMissionUseCase;
 import com.booquest.booquest_api.application.port.out.sidejob.SideJobRepositoryPort;
-import com.booquest.booquest_api.application.port.out.mission.MissionRepositoryPort;
-import com.booquest.booquest_api.domain.mission.model.Mission;
 import com.booquest.booquest_api.domain.sidejob.model.SideJob;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
@@ -25,7 +22,7 @@ public class SelectSideJobService implements SelectSideJobUseCase {
 
     @Override
     public List<SideJob> selectSideJobsByUserId(Long userId) {
-        return sideJobRepository.findAllByUserId(userId);
+        return sideJobRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
     }
 
 

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/character/model/UserCharacter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/character/model/UserCharacter.java
@@ -43,4 +43,8 @@ public class UserCharacter extends AuditableEntity {
         this.exp = Math.max(0, newExp);
     }
 
+    public UserCharacter withCharacterType(CharacterType type) {
+        this.characterType = type;
+        return this;
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/onboarding/model/OnboardingProfile.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/onboarding/model/OnboardingProfile.java
@@ -42,4 +42,19 @@ public class OnboardingProfile extends AuditableEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "strength_type", nullable = false)
     private StrengthType strengthType;
+
+    public OnboardingProfile withJob(String job) {
+        this.job = job;
+        return this;
+    }
+
+    public OnboardingProfile withExpressionStyle(ExpressionStyle expressionStyle) {
+        this.expressionStyle = expressionStyle;
+        return this;
+    }
+
+    public OnboardingProfile withStrengthType(StrengthType strengthType) {
+        this.strengthType = strengthType;
+        return this;
+    }
 }


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
-  온보딩을 사용자가 여러번 요청하는 경우를 대비해 온보딩 데이터 upsert로 수정
- OnboardingProgressInfo 유저가 선택한 부업 아이디 응답 추가
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->


## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 온보딩 프로필과 캐릭터생성은 upsert로 하고 ai로 생성된 부업을 저장하는 부분은 추후 ai 서버에서 진행하기 때문에 order by created_at desc limit 3 으로 테스트시에 문제없도록 하였습니다
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [x] 테스트를 모두 통과함
- [x] 문서/주석이 적절히 작성됨
- [x] Self Review 완료함
