### PR TITLE
[Fix] 메인퀘스트 목록 조회 시, 메인퀘스트 내부 진행률 추가

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionResponse.java
@@ -9,7 +9,6 @@ import lombok.Getter;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -45,7 +44,7 @@ public class MissionResponse {
     }
 
     private static MissionStepProgressResponse calculateProgress(Mission mission) {
-        Set<MissionStep> steps = mission.getSteps();
+        List<MissionStep> steps = mission.getSteps();
 
         int total = steps.size();
         long done = steps.stream().filter(MissionStep::isCompleted).count();

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionResponse.java
@@ -3,10 +3,13 @@ package com.booquest.booquest_api.adapter.in.mission.dto;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepResponse;
 import com.booquest.booquest_api.domain.mission.model.Mission;
 import com.booquest.booquest_api.domain.mission.enums.MissionStatus;
+import com.booquest.booquest_api.domain.missionstep.model.MissionStep;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Getter
@@ -20,10 +23,14 @@ public class MissionResponse {
     private String designNotes;
     private List<MissionStepResponse> steps;
 
+    private MissionStepProgressResponse progress;
+
     public static MissionResponse toResponse(Mission mission) {
         List<MissionStepResponse> stepResponses = mission.getSteps().stream()
                 .map(MissionStepResponse::toResponse)
                 .collect(Collectors.toList());
+
+        MissionStepProgressResponse progress = calculateProgress(mission);
 
         return MissionResponse.builder()
                 .id(mission.getId())
@@ -33,6 +40,28 @@ public class MissionResponse {
                 .orderNo(mission.getOrderNo())
                 .designNotes(mission.getDesignNotes())
                 .steps(stepResponses)
+                .progress(progress)
+                .build();
+    }
+
+    private static MissionStepProgressResponse calculateProgress(Mission mission) {
+        Set<MissionStep> steps = mission.getSteps();
+
+        int total = steps.size();
+        long done = steps.stream().filter(MissionStep::isCompleted).count();
+        int percent = (total == 0) ? 0 : (int) Math.round(done * 100.0 / total);
+
+        MissionStep current = steps.stream()
+                .filter(s -> !s.isCompleted())
+                .min(Comparator.comparingInt(MissionStep::getSeq))
+                .orElse(null);
+
+        return MissionStepProgressResponse.builder()
+                .percent(percent)
+                .completedStepCount((int) done)
+                .totalStepCount(total)
+                .currentStepId(current == null ? null : current.getId())
+                .currentStepOrder(current == null ? null : current.getSeq())
                 .build();
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionStepProgressResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionStepProgressResponse.java
@@ -1,0 +1,14 @@
+package com.booquest.booquest_api.adapter.in.mission.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MissionStepProgressResponse {
+    private int percent;              // 0~100
+    private int completedStepCount;   // 완료 스텝 수
+    private int totalStepCount;       // 전체 스텝 수
+    private Long currentStepId;       // 아직 완료 안 된 첫 스텝 id (없으면 null)
+    private Integer currentStepOrder; // 그 스텝의 seq/order (없으면 null)
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/mission/model/Mission.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/mission/model/Mission.java
@@ -3,17 +3,13 @@ package com.booquest.booquest_api.domain.mission.model;
 import com.booquest.booquest_api.common.entity.AuditableEntity;
 import com.booquest.booquest_api.domain.mission.enums.MissionStatus;
 import com.booquest.booquest_api.domain.missionstep.model.MissionStep;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.annotations.Type;
 import org.hibernate.type.SqlTypes;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 @Entity
 @AllArgsConstructor
@@ -49,7 +45,8 @@ public class Mission extends AuditableEntity {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "mission_id")
-    private Set<MissionStep> steps;
+    @OrderBy("seq ASC")
+    private List<MissionStep> steps = new ArrayList<>();
 
     public void updateTitleAndNotes(String title, String notes) {
         this.title = title;

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/sidejob/model/SideJob.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/sidejob/model/SideJob.java
@@ -2,16 +2,13 @@ package com.booquest.booquest_api.domain.sidejob.model;
 
 import com.booquest.booquest_api.common.entity.AuditableEntity;
 import com.booquest.booquest_api.domain.mission.model.Mission;
-import com.vladmihalcea.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 
 import lombok.*;
-import org.hibernate.annotations.Type;
 
 @Entity
 @AllArgsConstructor
@@ -47,5 +44,6 @@ public class SideJob extends AuditableEntity {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "sidejob_id")  // Mission 테이블의 FK 컬럼 이름
-    private Set<Mission> missions;
+    @OrderBy("orderNo ASC")
+    private List<Mission> missions = new ArrayList<>();
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
@@ -9,7 +9,8 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDateTime;
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @AllArgsConstructor
@@ -46,5 +47,6 @@ public class UserSideJob extends AuditableEntity {
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "sidejob_id")  // Mission 테이블의 FK 컬럼 이름
-    private Set<Mission> missions;
+    @OrderBy("orderNo ASC")
+    private List<Mission> missions = new ArrayList<>();
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
메인퀘스트 목록 조회 시, 메인퀘스트 내부 진행률 추가

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 메인퀘스트 목록 조회 시, 메인퀘스트 내부 진행률 추가
- Set -> List로 변경하여 목록 조회 시 정렬
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #이슈번호

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [ ] 코드가 정상 동작함
- [ ] 테스트를 모두 통과함
- [ ] 문서/주석이 적절히 작성됨
- [ ] Self Review 완료함
