### PR TITLE
[Feature] 사진 인증하기 API 구현

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/storage/persistence/LocalImageStorageAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/storage/persistence/LocalImageStorageAdapter.java
@@ -1,0 +1,76 @@
+package com.booquest.booquest_api.adapter.out.storage.persistence;
+
+import com.booquest.booquest_api.application.port.in.storage.ImageStoragePort;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+@Slf4j
+@Component
+public class LocalImageStorageAdapter implements ImageStoragePort {
+    private final String root;
+
+    public LocalImageStorageAdapter(@Value("${app.upload.root:/var/lib/booquest/uploads}") String root) {
+        this.root = root;
+    }
+
+    @Override
+    public StoredObject storeProofImage(Long userId, Long stepId, MultipartFile file) {
+        String ext = safeExt(file); // 구현
+        String key = String.format("proofs/%d/%d/%s.%s", userId, stepId, UUID.randomUUID(), ext);
+
+        Path dest = Paths.get(root, key).normalize();
+        try {
+            Files.createDirectories(dest.getParent());
+            try (InputStream in = file.getInputStream()) {
+                Files.copy(in, dest, StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException e) {
+            log.error("save fail: dest={}, root={}, size={}, type={}", dest, root, file.getSize(), file.getContentType(), e);
+            throw new UncheckedIOException("파일 저장 실패", e);
+        }
+
+        String publicUrl = "/uploads/" + key.replace("\\", "/");
+        return new StoredObject(key, publicUrl, file.getSize(), file.getContentType());
+    }
+
+    @Override
+    public void delete(String key) {
+        try {
+            Files.deleteIfExists(Paths.get(root, key));
+        } catch (IOException ignored) {}
+    }
+
+    private String safeExt(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null) contentType = "";
+
+        // Content-Type 타입 기준 우선
+        switch (contentType) {
+            case "image/jpeg": return "jpg";
+            case "image/png":  return "png";
+            case "image/webp": return "webp";
+        }
+
+        // 파일명 확장자로 보조 판단
+        String name = file.getOriginalFilename();
+        if (name != null) {
+            int i = name.lastIndexOf('.');
+            if (i > -1) {
+                String ext = name.substring(i + 1).toLowerCase();
+                if (ext.matches("jpe?g|png|webp")) return ext.equals("jpeg") ? "jpg" : ext;
+            }
+        }
+        throw new IllegalArgumentException("허용되지 않은 이미지 형식: " + contentType);
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/bonus/ProofUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/bonus/ProofUseCase.java
@@ -2,7 +2,9 @@ package com.booquest.booquest_api.application.port.in.bonus;
 
 import com.booquest.booquest_api.adapter.in.bonus.dto.BonusResponse;
 import com.booquest.booquest_api.adapter.in.bonus.dto.ProofRequest;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface ProofUseCase {
     BonusResponse submitProofAndGrantExp(Long userId, Long stepId, ProofRequest request);
+    BonusResponse submitImageProofAndGrantExp(Long userId, Long stepId, MultipartFile file);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/storage/ImageStoragePort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/storage/ImageStoragePort.java
@@ -1,0 +1,9 @@
+package com.booquest.booquest_api.application.port.in.storage;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageStoragePort {
+    record StoredObject(String key, String publicUrl, long size, String contentType) {}
+    StoredObject storeProofImage(Long userId, Long stepId, MultipartFile file);
+    void delete(String key); // 실패 시 롤백/정리용
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/bonus/ProofService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/bonus/ProofService.java
@@ -4,11 +4,13 @@ import com.booquest.booquest_api.adapter.in.bonus.dto.BonusResponse;
 import com.booquest.booquest_api.adapter.in.bonus.dto.ProofRequest;
 import com.booquest.booquest_api.application.port.in.bonus.ProofUseCase;
 import com.booquest.booquest_api.application.port.in.character.UpdateCharacterExpUseCase;
+import com.booquest.booquest_api.application.port.in.storage.ImageStoragePort;
 import com.booquest.booquest_api.application.port.out.bonus.AdViewRepositoryPort;
 import com.booquest.booquest_api.application.port.out.bonus.ProofRepositoryPort;
 import com.booquest.booquest_api.application.port.out.mission.MissionRepositoryPort;
 import com.booquest.booquest_api.application.port.out.missionstep.MissionStepRepositoryPort;
 import com.booquest.booquest_api.domain.bonus.enums.BonusStatus;
+import com.booquest.booquest_api.domain.bonus.enums.ProofType;
 import com.booquest.booquest_api.domain.bonus.model.Proof;
 import com.booquest.booquest_api.domain.character.enums.RewardType;
 import com.booquest.booquest_api.domain.character.policy.CharacterRewardPolicy;
@@ -19,6 +21,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +32,7 @@ public class ProofService implements ProofUseCase {
     private final AdViewRepositoryPort adViewRepositoryPort;
     private final UpdateCharacterExpUseCase updateCharacterExpUseCase;
     private final CharacterRewardPolicy rewardPolicy;
+    private final ImageStoragePort imageStoragePort;
 
     @Override
     @Transactional
@@ -75,4 +79,40 @@ public class ProofService implements ProofUseCase {
     }
 
     private record CompletedCheck(boolean completed) {}
+
+    @Transactional
+    public BonusResponse submitImageProofAndGrantExp(Long userId, Long stepId, MultipartFile file) {
+        var check = checkUserPermissionAndStepCompleted(userId, stepId);
+        if (!check.completed) return new BonusResponse(BonusStatus.NOT_COMPLETED, 0);
+        if (adViewRepositoryPort.existsCompletedByUserIdAndStepId(userId, stepId))
+            return new BonusResponse(BonusStatus.BLOCKED_BY_AD, 0);
+        if (proofRepositoryPort.existsByUserIdAndStepId(userId, stepId))
+            return new BonusResponse(BonusStatus.ALREADY_VERIFIED, 0);
+
+        validateImage(file); // mime, size, 확장자, 매직바이트 등
+
+        // 저장
+        var stored = imageStoragePort.storeProofImage(userId, stepId, file);
+
+        // 저장된 URL/키로 Proof 생성
+        Proof proof = Proof.builder()
+                .userId(userId)
+                .stepId(stepId)
+                .proofType(ProofType.IMAGE)
+                .content(stored.publicUrl()) // 또는 key 저장 후 요청 시 signed URL 생성 전략이면 key 저장
+                .isVerified(true)
+                .build();
+        proofRepositoryPort.save(proof);
+
+        updateCharacterExpUseCase.applyReward(userId, RewardType.PROOF_VERIFIED);
+        int additionalExp = rewardPolicy.expDeltaFor(RewardType.PROOF_VERIFIED);
+        return new BonusResponse(BonusStatus.GRANTED, additionalExp);
+    }
+
+    private void validateImage(MultipartFile file) {
+        if (file.isEmpty()) throw new IllegalArgumentException("파일이 비어 있습니다.");
+        long max = 10 * 1024 * 1024; // 10MB 임의로 설정
+        if (file.getSize() > max) throw new IllegalArgumentException("파일이 너무 큽니다.");
+        // content-type과 magic bytes 동시 체크 권장 (jpg, png, webp, heic 등 정책 결정)
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/config/StaticResourceConfig.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/config/StaticResourceConfig.java
@@ -1,0 +1,18 @@
+package com.booquest.booquest_api.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class StaticResourceConfig implements WebMvcConfigurer {
+    @Value("${app.upload.root:/var/app/uploads}")
+    private String root;
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/uploads/**")
+                .addResourceLocations("file:" + root + "/");
+    }
+}

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
   profiles:
     active: dev
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 12MB
+
 server:
   error:
     include-exception: true


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
사진 인증하기 API 구현

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 사진 인증하기 API 구현
- 
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #51

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 사진 인증용 로컬 이미지 저장 및 업로드 엔드포인트 추가
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [x] 테스트를 모두 통과함
- [x] 문서/주석이 적절히 작성됨
- [x] Self Review 완료함
