### PR TITLE
[Feat] 부퀘스트 생성 / 재생성시 부업 정보 함께 전달

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/MissionStepController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/MissionStepController.java
@@ -1,9 +1,11 @@
 package com.booquest.booquest_api.adapter.in.missionstep;
 
+import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepAiRequestDto;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepGenerateRequestDto;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepResponseDto;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepUpdateStatusRequest;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.MissionStepUpdateStatusResponse;
+import com.booquest.booquest_api.adapter.in.missionstep.dto.RegenerateMissionStepAIRequest;
 import com.booquest.booquest_api.adapter.in.missionstep.dto.RegenerateMissionStepRequest;
 import com.booquest.booquest_api.application.port.in.mission.SelectMissionUseCase;
 import com.booquest.booquest_api.application.port.in.missionstep.DeleteMissionStepUseCase;
@@ -47,9 +49,6 @@ public class MissionStepController {
     private final SelectMissionUseCase selectMissionUseCase;
     private final SelectSideJobUseCase selectSideJobUseCase;
 
-    record MissionStepAiRequestDto(long userId, Long missionId, String missionTitle, String missionDesignNotes,
-                                   int orderNo, String sideJobTitle, String sideJobDescription) {}
-
     @PostMapping()
     @Operation(summary = "부퀘스트 생성", description = "부퀘스트를 생성합니다.")
     public ApiResponse<List<MissionStepResponseDto>> generate(
@@ -65,14 +64,7 @@ public class MissionStepController {
             return ApiResponse.success("부퀘스트가 이미 존재합니다.", missionSteps);
         }
 
-        SideJob sideJob = selectSideJobUseCase.getSelectedSideJobsByUserId(requestDto.userId());
-        int orderNo = selectMissionUseCase.selectOrderNoByMissionId(requestDto.missionId());
-
-        MissionStepAiRequestDto aiRequest = new MissionStepAiRequestDto(
-                requestDto.userId(), requestDto.missionId(), requestDto.missionTitle(), requestDto.missionDesignNotes(),
-                orderNo, sideJob.getTitle(), sideJob.getDescription()
-        );
-
+        MissionStepAiRequestDto aiRequest = generateMissionStepAiRequestDto(requestDto);
 
         String raw = webClient.post()                                   // POST로 호출해야 해서 필요
                 .uri("/ai/generate-mission-step")                   // 호출할 AI 경로 지정 — 필요
@@ -85,6 +77,16 @@ public class MissionStepController {
         List<MissionStepResponseDto> missionSteps = JsonMapperUtils.parse(raw, new TypeReference<>() {});
 
         return ApiResponse.success("부퀘스트가 생성되었습니다.", missionSteps);
+    }
+
+    private MissionStepAiRequestDto generateMissionStepAiRequestDto(MissionStepGenerateRequestDto requestDto) {
+        SideJob sideJob = selectSideJobUseCase.getSelectedSideJobsByUserId(requestDto.userId());
+        int orderNo = selectMissionUseCase.selectOrderNoByMissionId(requestDto.missionId());
+
+        return new MissionStepAiRequestDto(
+                requestDto.userId(), requestDto.missionId(), requestDto.missionTitle(), requestDto.missionDesignNotes(),
+                orderNo, sideJob.getTitle(), sideJob.getDescription()
+        );
     }
 
     @GetMapping("/{stepId}")
@@ -112,6 +114,10 @@ public class MissionStepController {
     @Operation(summary = "부퀘스트 목록 재생성", description = "유저 피드백에 따라 부퀘스트 목록을 재생성합니다.")
     public ApiResponse<List<MissionStepResponseDto>> regenerateAll(@RequestBody @Valid RegenerateMissionStepRequest request) {
 
+        MissionStepAiRequestDto aiRequest = generateMissionStepAiRequestDto(request.generateMissionStep());
+        RegenerateMissionStepAIRequest missionStepAIRequest = new RegenerateMissionStepAIRequest(
+                request.feedbackData(), aiRequest);
+
         //이전 부퀘스트 삭제
         deleteMissionStepUseCase.deleteAllByMissionId(request.generateMissionStep().missionId());
         //부퀘스트 생성 요청
@@ -119,7 +125,7 @@ public class MissionStepController {
         String raw = webClient.post()                                   // POST로 호출해야 해서 필요
                 .uri("/ai/regenerate-mission-step")                           // 호출할 AI 경로 지정 — 필요
                 .contentType(MediaType.APPLICATION_JSON)                       // 요청 바디가 JSON임을 명시 — 필요
-                .bodyValue(request)                                             // 보낼 페이로드 지정 — 필요
+                .bodyValue(missionStepAIRequest)                                             // 보낼 페이로드 지정 — 필요
                 .retrieve()                                                    // 요청 실행 트리거 — 필요
                 .bodyToMono(String.class)                                      // 응답 바디를 “문자열”로 그대로 받음(파싱 없음) — 필요
                 .block();

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/MissionStepAiRequestDto.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/MissionStepAiRequestDto.java
@@ -1,0 +1,11 @@
+package com.booquest.booquest_api.adapter.in.missionstep.dto;
+
+public record MissionStepAiRequestDto(
+        long userId,
+        Long missionId,
+        String missionTitle,
+        String missionDesignNotes,
+        int orderNo,
+        String sideJobTitle,
+        String sideJobDescription)
+{}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/RegenerateMissionStepAIRequest.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/RegenerateMissionStepAIRequest.java
@@ -1,0 +1,6 @@
+package com.booquest.booquest_api.adapter.in.missionstep.dto;
+
+import com.booquest.booquest_api.adapter.in.missionstep.dto.RegenerateMissionStepRequest.RegenerateFeedbackData;
+
+public record RegenerateMissionStepAIRequest (RegenerateFeedbackData feedbackData, MissionStepAiRequestDto generateMissionStep){
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/mission/persisitence/MissionRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/mission/persisitence/MissionRepository.java
@@ -57,4 +57,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("delete from Mission m where m.userId = :userId")
     int deleteByUserId(@Param("userId") Long userId);
+
+    @Query("select m.orderNo from Mission m where m.id = :missionId")
+    Optional<Integer> findOrderNoById(Long missionId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/mission/persisitence/MissionRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/mission/persisitence/MissionRepositoryAdapter.java
@@ -79,4 +79,10 @@ public class MissionRepositoryAdapter implements MissionRepositoryPort {
     public List<Mission> findBySideJobId(Long sideJobId) {
         return missionRepository.findMissionsBySideJobId(sideJobId);
     }
+
+    @Override
+    public Integer findOrderNoById(Long missionId) {
+        return missionRepository.findOrderNoById(missionId)
+                .orElseThrow(() -> new IllegalArgumentException("orderNo가 존재하지 않습니다."));
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepository.java
@@ -42,4 +42,7 @@ public interface SideJobRepository extends JpaRepository<SideJob, Long> {
     long deleteByUserId(Long userId);
 
     Optional<SideJob> findByIdAndUserId(Long id, Long userId);
+
+    @Query("select s from SideJob s where s.userId = :userId and s.isSelected = true")
+    Optional<SideJob> findSelectedSideJobByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/sidejob/persistence/SideJobRepositoryAdapter.java
@@ -50,7 +50,7 @@ public class SideJobRepositoryAdapter implements SideJobRepositoryPort {
     }
 
     @Override
-    public Long findSelectedSideJobByUserId(Long userId) {
+    public Long findSelectedSideJobIdByUserId(Long userId) {
         return sideJobRepository.findTopSelectedSideJobId(userId)
                 .orElse(null);
     }
@@ -58,6 +58,11 @@ public class SideJobRepositoryAdapter implements SideJobRepositoryPort {
     @Override
     public long deleteByUserId(Long userId) {
         return sideJobRepository.deleteByUserId(userId);
+    }
+
+    @Override
+    public Optional<SideJob> findSelectedSideJobByUserId(Long userId) {
+        return sideJobRepository.findSelectedSideJobByUserId(userId);
     }
 
     @Override

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/mission/SelectMissionUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/mission/SelectMissionUseCase.java
@@ -8,4 +8,6 @@ public interface SelectMissionUseCase {
     Mission selectMission(Long missionId);
 
     List<Mission> selectMissionBySideJobId(Long sideJobId);
+
+    int selectOrderNoByMissionId(Long missionId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/sidejob/SelectSideJobUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/sidejob/SelectSideJobUseCase.java
@@ -8,4 +8,6 @@ public interface SelectSideJobUseCase {
     SideJob selectSideJob(Long sideJobId);
 
     List<SideJob> selectSideJobsByUserId(Long userId);
+
+    SideJob getSelectedSideJobsByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/mission/MissionRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/mission/MissionRepositoryPort.java
@@ -3,8 +3,10 @@ package com.booquest.booquest_api.application.port.out.mission;
 import com.booquest.booquest_api.domain.mission.model.Mission;
 import com.booquest.booquest_api.domain.mission.enums.MissionStatus;
 
+import jakarta.persistence.criteria.CriteriaBuilder.In;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MissionRepositoryPort {
     Mission save(Mission mission);
@@ -32,4 +34,6 @@ public interface MissionRepositoryPort {
     long deleteByUserId(Long userId);
 
     List<Mission> findBySideJobId(Long sideJobId);
+
+    Integer findOrderNoById(Long missionId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/sidejob/SideJobRepositoryPort.java
@@ -19,7 +19,7 @@ public interface SideJobRepositoryPort {
 
     List<SideJob> findTop3ByUserIdOrderByCreatedAtDesc(Long userId);
 
-    Long findSelectedSideJobByUserId(Long userId);
+    Long findSelectedSideJobIdByUserId(Long userId);
 
     void deleteAll(List<SideJob> sideJobs);
 
@@ -30,4 +30,6 @@ public interface SideJobRepositoryPort {
     Optional<SideJob> findById(Long sideJobSelectedId);
 
     long deleteByUserId(Long userId);
+
+    Optional<SideJob> findSelectedSideJobByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/mission/SelectMissionService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/mission/SelectMissionService.java
@@ -24,4 +24,9 @@ public class SelectMissionService implements SelectMissionUseCase {
     public List<Mission> selectMissionBySideJobId(Long sideJobId) {
         return missionRepository.findBySideJobId(sideJobId);
     }
+
+    @Override
+    public int selectOrderNoByMissionId(Long missionId) {
+        return missionRepository.findOrderNoById(missionId);
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/CheckSideJobStatusService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/CheckSideJobStatusService.java
@@ -33,6 +33,6 @@ public class CheckSideJobStatusService implements CheckSideJobStatusUseCase {
 
     @Override
     public Long getSelectedSideJobId(Long userId) {
-        return sideJobRepositoryPort.findSelectedSideJobByUserId(userId);
+        return sideJobRepositoryPort.findSelectedSideJobIdByUserId(userId);
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/SelectSideJobService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/sidejob/SelectSideJobService.java
@@ -25,5 +25,11 @@ public class SelectSideJobService implements SelectSideJobUseCase {
         return sideJobRepository.findTop3ByUserIdOrderByCreatedAtDesc(userId);
     }
 
+    @Override
+    public SideJob getSelectedSideJobsByUserId(Long userId) {
+        return sideJobRepository.findSelectedSideJobByUserId(userId)
+                .orElseThrow(() -> new EntityNotFoundException("SideJob not found"));
+    }
+
 
 }


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 부퀘스트 생성시 결과 정확도를 높이기 위해 유저의 부업 정보를 함께 전달

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #41 

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- ai 서버에서 정보를 조회하는 방법도 생각해봤는데 자바단에서 조회해오는게 가장 빠를거같아서 이렇게 진행했습니다

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [ ] 코드가 정상 동작함
- [ ] 테스트를 모두 통과함
- [ ] 문서/주석이 적절히 작성됨
- [ ] Self Review 완료함
