### PR TITLE
[fix] 메인퀘스트 완료시 부업 완료 처리 수정

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepository.java
@@ -56,4 +56,6 @@ public interface UserSideJobRepository extends JpaRepository<UserSideJob, Long> 
                                                 @Param("status") UserSideJobStatus status);
 
     long deleteByUserId(Long userId);
+
+    Optional<UserSideJob> findBySideJobId(Long sideJobId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/usersidejob/persistence/UserSideJobRepositoryAdapter.java
@@ -42,6 +42,11 @@ public class UserSideJobRepositoryAdapter implements UserSideJobRepositoryPort, 
     }
 
     @Override
+    public Optional<UserSideJob> findBySideJobId(Long sideJobId) {
+        return userSideJobRepository.findBySideJobId(sideJobId);
+    }
+
+    @Override
     public int countCompletedSideJobsByUserId(Long userId) {
         return (int) userSideJobRepository.countCompletedByUserId(userId, UserSideJobStatus.COMPLETED);
     }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/usersidejob/UserSideJobRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/usersidejob/UserSideJobRepositoryPort.java
@@ -15,4 +15,6 @@ public interface UserSideJobRepositoryPort {
     Optional<UserSideJob> findLatestSideJobForStatus(Long userId);
 
     long deleteByUserId(Long userId);
+
+    Optional<UserSideJob> findBySideJobId(Long id);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobSummaryService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/usersidejob/GetUserSideJobSummaryService.java
@@ -28,7 +28,7 @@ public class GetUserSideJobSummaryService implements GetUserSideJobSummaryUseCas
 
         BigDecimal totalIncome = incomeRepositoryPort.sumByUserAndSideJob(userId, userSideJobId);
 
-        int completedQuestCount = missionStepRepositoryPort.countCompletedByUserAndSideJob(userId, userSideJobId);
+        int completedQuestCount = missionStepRepositoryPort.countCompletedByUserAndSideJob(userId, userSideJob.getSideJobId());
 
         int daysToFirstIncome = 0;
         LocalDate startedDate = null;

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/sidejob/model/SideJob.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/sidejob/model/SideJob.java
@@ -55,4 +55,8 @@ public class SideJob extends AuditableEntity {
     public void markSelected() {
         this.isSelected = true;
     }
+
+    public void complete() {
+        this.endedAt = LocalDateTime.now();
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/usersidejob/model/UserSideJob.java
@@ -51,4 +51,9 @@ public class UserSideJob extends AuditableEntity {
     @JoinColumn(name = "sidejob_id")  // Mission 테이블의 FK 컬럼 이름
     @OrderBy("orderNo ASC")
     private Set<Mission> missions = new LinkedHashSet<>();
+
+    public void complete() {
+        endedAt = LocalDateTime.now();
+        status = UserSideJobStatus.COMPLETED;
+    }
 }


### PR DESCRIPTION

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 메인퀘스트 전부 완료시 부업 완료처리
- completedQuestCount 계산 안되는 문제 해결
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved:

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 부업의 메인퀘스트가 전부 완료된 경우 부업 및 사용자 부업 완료 처리
- completedQuestCount계산시 메소드 파라미터로 부업 아이디가 아닌 유저 부업 아이디를 넣는 문제 해결

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [x] 테스트를 모두 통과함
- [x] 문서/주석이 적절히 작성됨
- [ ] Self Review 완료함
