### PR TITLE
[Feature] 경험치 쌓이는 API들 응답값에 레벨업 여부(leveledUp), 현재 레벨/오른 레벨(currentLevel) 추가

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/bonus/dto/BonusResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/bonus/dto/BonusResponse.java
@@ -5,5 +5,7 @@ import com.booquest.booquest_api.domain.bonus.enums.BonusStatus;
 public record BonusResponse(
         BonusStatus status,
         int additionalExp,
-        int totalStepExp
+        int totalStepExp,
+        boolean leveledUp,
+        int currentLevel
 ) {}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionCompleteResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/mission/dto/MissionCompleteResponse.java
@@ -20,6 +20,8 @@ public class MissionCompleteResponse {
     private int levelUpCount; // 레벨업 횟수
     private int previousLevel; // 이전 레벨
     private boolean missionCompleted; // 메인퀘스트 완료 여부
+    private boolean leveledUp; // 이번 처리에서 레벨업 여부
+    private int currentLevel; // 레벨업 후 최종 레벨
 
     public static MissionCompleteResponse toResponse(Mission mission, UserCharacter character,
                                                    int totalExpReward, int stepExpReward, 
@@ -47,6 +49,8 @@ public class MissionCompleteResponse {
                 .levelUpCount(levelUpCount)
                 .previousLevel(previousLevel)
                 .missionCompleted(missionCompleted)
+                .leveledUp(levelUpCount > 0)
+                .currentLevel(character != null ? character.getLevel() : 0)
                 .build();
     }
-} 
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/MissionStepUpdateStatusResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/missionstep/dto/MissionStepUpdateStatusResponse.java
@@ -12,14 +12,19 @@ public class MissionStepUpdateStatusResponse {
     private MissionStepResponse step;
     private UserCharacterResponse character;
     private int expDelta; // 경험치: 완료 +10, 완료취소 -10, 그 외 0
+    private boolean leveledUp; // 이번 처리에서 레벨업 여부
+    private int currentLevel; // 레벨업 후 최종 레벨
 
     public static MissionStepUpdateStatusResponse toResponse(MissionStep updatedStep,
                                                              UserCharacter updatedCharacter,
-                                                             int expDelta) {
+                                                             int expDelta,
+                                                             int previousLevel) {
         return MissionStepUpdateStatusResponse.builder()
                 .step(MissionStepResponse.toResponse(updatedStep))
                 .character(UserCharacterResponse.toResponse(updatedCharacter))
                 .expDelta(expDelta)
+                .leveledUp(updatedCharacter.getLevel() > previousLevel)
+                .currentLevel(updatedCharacter.getLevel())
                 .build();
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/missionstep/UpdateMissionStepStatusService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/missionstep/UpdateMissionStepStatusService.java
@@ -35,17 +35,21 @@ public class UpdateMissionStepStatusService implements UpdateMissionStepStatusUs
 
         if (oldStatus == newStatus) {
             RewardType rewardType = RewardType.NONE;
+            UserCharacter before = characterRewardService.getCharacter(userId);
+            int previousLevel = before.getLevel();
             UserCharacter character = characterRewardService.applyReward(userId, rewardType);
             int delta = characterRewardPolicy.expDeltaFor(rewardType); // 0
-            return buildResponse(step, character, delta);
+            return buildResponse(step, character, delta, previousLevel);
         }
 
         updateStepStatus(step, newStatus);
 
         RewardType rewardType = mapRewardType(oldStatus, newStatus);
+        UserCharacter before = characterRewardService.getCharacter(userId);
+        int previousLevel = before.getLevel();
         UserCharacter character = characterRewardService.applyReward(userId, rewardType);
         int delta = characterRewardPolicy.expDeltaFor(rewardType);
-        return buildResponse(step, character, delta);
+        return buildResponse(step, character, delta, previousLevel);
     }
 
     private MissionStep getMissionStep(Long stepId) {
@@ -75,8 +79,8 @@ public class UpdateMissionStepStatusService implements UpdateMissionStepStatusUs
         return RewardType.NONE;
     }
 
-    private MissionStepUpdateStatusResponse buildResponse(MissionStep step, UserCharacter character, int delta) {
-        return MissionStepUpdateStatusResponse.toResponse(step, character, delta);
+    private MissionStepUpdateStatusResponse buildResponse(MissionStep step, UserCharacter character, int delta, int previousLevel) {
+        return MissionStepUpdateStatusResponse.toResponse(step, character, delta, previousLevel);
     }
 
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
경험치 쌓이는 API들 응답값에 레벨업 여부(leveledUp), 현재 레벨/오른 레벨(currentLevel) 추가

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 경험치 쌓이는 API들 응답값에 레벨업 여부(leveledUp), 현재 레벨/오른 레벨(currentLevel) 추가
- 
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #이슈번호

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [ ] 코드가 정상 동작함
- [ ] 테스트를 모두 통과함
- [ ] 문서/주석이 적절히 작성됨
- [ ] Self Review 완료함
