### PR TITLE
[Feat] 애플 로그인 / 회원 탈퇴 구현

### DIFF
--- a/booquest-api/build.gradle
+++ b/booquest-api/build.gradle
@@ -47,6 +47,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
 	
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/user/UserController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/user/UserController.java
@@ -71,4 +71,14 @@ public class UserController {
         DeleteAccountResponse result = deleteAccountUseCase.deleteUserCompletely(userId, providerAccessToken);
         return ApiResponse.success("계정이 탈퇴되었습니다.", result);
     }
+
+    @DeleteMapping("/me/apple")
+    @Operation(summary = "애플 계정 탈퇴", description = "서버에 저장된 refresh_token으로 애플 계정을 revoke한 후 사용자 데이터를 삭제합니다.")
+    public ApiResponse<DeleteAccountResponse> deleteAppleUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.parseLong(auth.getName());
+
+        DeleteAccountResponse result = deleteAccountUseCase.deleteAppleUserCompletely(userId);
+        return ApiResponse.success("Apple 계정이 탈퇴되었습니다.", result);
+    }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
@@ -4,7 +4,7 @@ import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.JWSSigner;
-import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.security.KeyFactory;
@@ -40,7 +40,7 @@ public class AppleClientSecretGenerator {
             long now = Instant.now().getEpochSecond();
             long exp = now + 86400 * 180; // 180일
 
-            JWSSigner signer = new RSASSASigner(getPrivateKey());
+            JWSSigner signer = new ECDSASigner(getPrivateKey());
 
             JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
                     .issuer(teamId)

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
@@ -68,8 +68,10 @@ public class AppleClientSecretGenerator {
 
     private ECPrivateKey getPrivateKey() {
         try {
-            String pkcs8Pem = privateKey.replace("-----BEGIN PRIVATE KEY-----", "")
+            String pkcs8Pem = privateKey
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
                     .replace("-----END PRIVATE KEY-----", "")
+                    .replace("\\n", "")
                     .replaceAll("\\s+", "");
 
             byte[] decoded = Base64.getDecoder().decode(pkcs8Pem);

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleClientSecretGenerator.java
@@ -1,0 +1,83 @@
+package com.booquest.booquest_api.adapter.out.auth.oauth;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import java.security.KeyFactory;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class AppleClientSecretGenerator {
+
+    @Value("${apple.auth.team-id}")
+    private String teamId;
+
+    @Value("${apple.auth.key-id}")
+    private String keyId;
+
+    @Value("${apple.auth.client-id}")
+    private String clientId;
+
+    @Value("${apple.auth.private-key}")
+    private String privateKey;
+
+    public String generate() {
+        try {
+            long now = Instant.now().getEpochSecond();
+            long exp = now + 86400 * 180; // 180일
+
+            JWSSigner signer = new RSASSASigner(getPrivateKey());
+
+            JWTClaimsSet claimsSet = new JWTClaimsSet.Builder()
+                    .issuer(teamId)
+                    .issueTime(Date.from(Instant.ofEpochSecond(now)))
+                    .expirationTime(Date.from(Instant.ofEpochSecond(exp)))
+                    .audience("https://appleid.apple.com")
+                    .subject(clientId)
+                    .build();
+
+            SignedJWT signedJWT = new SignedJWT(
+                    new JWSHeader.Builder(JWSAlgorithm.ES256).keyID(keyId).build(),
+                    claimsSet
+            );
+
+            signedJWT.sign(signer);
+            return signedJWT.serialize();
+        } catch (JOSEException e) {
+            log.error("[AppleClientSecret] 서명 생성 실패", e);
+            return null;
+        } catch (Exception e) {
+            log.error("[AppleClientSecret] 알 수 없는 오류", e);
+            return null;
+        }
+    }
+
+    private ECPrivateKey getPrivateKey() {
+        try {
+            String pkcs8Pem = privateKey.replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s+", "");
+
+            byte[] decoded = Base64.getDecoder().decode(pkcs8Pem);
+            KeyFactory kf = KeyFactory.getInstance("EC");
+            return (ECPrivateKey) kf.generatePrivate(new PKCS8EncodedKeySpec(decoded));
+        } catch (Exception e) {
+            throw new RuntimeException("Apple private key 로드 실패", e);
+        }
+    }
+}
+

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleOAuthClient.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleOAuthClient.java
@@ -1,0 +1,60 @@
+package com.booquest.booquest_api.adapter.out.auth.oauth;
+
+import com.booquest.booquest_api.application.port.out.auth.OAuthClientPort;
+import com.booquest.booquest_api.domain.auth.enums.AuthProvider;
+import com.booquest.booquest_api.domain.user.model.SocialUser;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.RemoteJWKSet;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import java.net.URL;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleOAuthClient implements OAuthClientPort {
+
+    @Value("${apple.api.jwks-uri}")
+    private String jwksUri;
+
+    @Override
+    public SocialUser fetchUserInfo(String identityToken) {
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(identityToken);
+
+            // 공개 키로 서명 검증
+            JWSVerificationKeySelector<SecurityContext> keySelector = new JWSVerificationKeySelector<>(
+                    JWSAlgorithm.RS256, new RemoteJWKSet<>(new URL(jwksUri))
+            );
+
+            ConfigurableJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            jwtProcessor.setJWSKeySelector(keySelector);
+
+            var claims = jwtProcessor.process(signedJWT, null);
+
+            String email = claims.getStringClaim("email");
+            String userId = claims.getSubject(); // sub 필드 (고유 식별자)
+
+            log.info("Apple 로그인 응답: email={}, sub={}", email, userId);
+
+            return SocialUser.builder()
+                    .email(email)
+                    .nickname(null) // 애플은 nickname 미제공
+                    .provider(AuthProvider.APPLE)
+                    .providerId(userId)
+                    .profileImageUrl(null)
+                    .build();
+
+        } catch (Exception e) {
+            log.error("Apple identity token 처리 중 오류", e);
+            throw new RuntimeException("Apple 로그인 실패", e);
+        }
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleUnlinkClient.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/AppleUnlinkClient.java
@@ -1,0 +1,47 @@
+package com.booquest.booquest_api.adapter.out.auth.oauth;
+
+import com.booquest.booquest_api.application.port.out.auth.AppleUnlinkPort;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AppleUnlinkClient implements AppleUnlinkPort {
+    private final WebClient webClient;
+
+    @Value("${apple.auth.client-id}")
+    private String clientId;
+    private AppleClientSecretGenerator secretGenerator;
+
+    @Override
+    public boolean revokeToken(String refreshToken) {
+        String clientSecret = secretGenerator.generate();
+
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("client_id", clientId);
+        formData.add("client_secret", clientSecret);
+        formData.add("token", refreshToken);
+        formData.add("token_type_hint", "refresh_token");
+
+        try {
+            webClient.post()
+                    .uri("https://appleid.apple.com/auth/revoke")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .bodyValue(formData)
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+            return true;
+        } catch (Exception e) {
+            log.error("Apple refresh_token revoke 실패", e);
+            return false;
+        }
+    }
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/SocialUnlinkClient.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/SocialUnlinkClient.java
@@ -37,6 +37,11 @@ public class SocialUnlinkClient implements SocialUnlinkPort {
                 }
                 return naverUnlinkPort.unlinkByAccessToken(providerAccessToken);
             }
+            case APPLE -> {
+                // Apple은 서버 측에서 unlink 불가 → 단순 성공 처리
+                log.info("[SocialUnlink] Apple은 서버에서 unlink 불가. providerUserId={}", providerUserId);
+                return true;
+            }
             default -> {
                 log.info("[SocialUnlink] Unsupported provider={}, treat as success", provider);
                 return true;

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/SocialUnlinkClient.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/SocialUnlinkClient.java
@@ -1,8 +1,10 @@
 package com.booquest.booquest_api.adapter.out.auth.oauth;
 
+import com.booquest.booquest_api.application.port.out.auth.AppleUnlinkPort;
 import com.booquest.booquest_api.application.port.out.auth.KakaoUnlinkPort;
 import com.booquest.booquest_api.application.port.out.auth.NaverUnlinkPort;
 import com.booquest.booquest_api.application.port.out.auth.SocialUnlinkPort;
+import com.booquest.booquest_api.application.port.out.auth.TokenRepositoryPort;
 import com.booquest.booquest_api.domain.auth.enums.AuthProvider;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +17,8 @@ import org.springframework.stereotype.Component;
 public class SocialUnlinkClient implements SocialUnlinkPort {
     private final KakaoUnlinkPort kakaoUnlinkPort;
     private final NaverUnlinkPort naverUnlinkPort;
+    private final AppleUnlinkPort appleUnlinkPort;
+    private final TokenRepositoryPort tokenRepositoryPort;
 
     @Override
     public boolean unlink(AuthProvider provider, String providerUserId, @Nullable String providerAccessToken) {
@@ -37,15 +41,22 @@ public class SocialUnlinkClient implements SocialUnlinkPort {
                 }
                 return naverUnlinkPort.unlinkByAccessToken(providerAccessToken);
             }
-            case APPLE -> {
-                // Apple은 서버 측에서 unlink 불가 → 단순 성공 처리
-                log.info("[SocialUnlink] Apple은 서버에서 unlink 불가. providerUserId={}", providerUserId);
-                return true;
-            }
             default -> {
                 log.info("[SocialUnlink] Unsupported provider={}, treat as success", provider);
                 return true;
             }
         }
+    }
+
+    @Override
+    public boolean unlinkApple(Long userId) {
+        // refreshToken이 유효할 때 처리
+        return tokenRepositoryPort.findRefreshTokenByUserId(userId)
+                .filter(token -> !token.isBlank())
+                .map(appleUnlinkPort::revokeToken)
+                .orElseGet(() -> {
+                    log.warn("[SocialUnlink] Apple refresh_token not found or blank for userId={}", userId);
+                    return false;
+                });
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/dto/AppleTokenResponse.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/oauth/dto/AppleTokenResponse.java
@@ -1,0 +1,24 @@
+package com.booquest.booquest_api.adapter.out.auth.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AppleTokenResponse {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/persistence/AppleRefreshTokenRepository.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/persistence/AppleRefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.booquest.booquest_api.adapter.out.auth.persistence;
+
+import com.booquest.booquest_api.domain.auth.model.AppleRefreshToken;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
+    @Query("SELECT a.refreshToken FROM AppleRefreshToken a WHERE a.userId = :userId")
+    Optional<String> findByUserId(Long userId);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/persistence/TokenRepositoryAdapter.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/out/auth/persistence/TokenRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package com.booquest.booquest_api.adapter.out.auth.persistence;
 
 import com.booquest.booquest_api.application.port.out.auth.TokenRepositoryPort;
+import com.booquest.booquest_api.domain.auth.model.AppleRefreshToken;
 import com.booquest.booquest_api.domain.auth.model.Token;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -13,6 +14,7 @@ import java.util.Optional;
 public class TokenRepositoryAdapter implements TokenRepositoryPort {
 
     private final TokenRepository tokenRepository;
+    private final AppleRefreshTokenRepository appleRefreshTokenRepository;
 
     @Override
     public Token save(Token token) {
@@ -42,5 +44,15 @@ public class TokenRepositoryAdapter implements TokenRepositoryPort {
     @Override
     public int upsertByUserId(Long userId, String refreshTokenHash, LocalDateTime expiresAt) {
         return tokenRepository.upsertByUserId(userId, refreshTokenHash, java.sql.Timestamp.valueOf(expiresAt));
+    }
+
+    @Override
+    public void saveAppleRefreshToken(AppleRefreshToken appleRefreshToken) {
+        appleRefreshTokenRepository.save(appleRefreshToken);
+    }
+
+    @Override
+    public Optional<String> findRefreshTokenByUserId(Long userId) {
+        return appleRefreshTokenRepository.findByUserId(userId);
     }
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/user/DeleteAccountUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/user/DeleteAccountUseCase.java
@@ -5,4 +5,6 @@ import jakarta.annotation.Nullable;
 
 public interface DeleteAccountUseCase {
     DeleteAccountResponse deleteUserCompletely(Long userId, @Nullable String providerAccessToken);
+
+    DeleteAccountResponse deleteAppleUserCompletely(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/AppleUnlinkPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/AppleUnlinkPort.java
@@ -1,0 +1,5 @@
+package com.booquest.booquest_api.application.port.out.auth;
+
+public interface AppleUnlinkPort {
+    boolean revokeToken(String refreshToken);
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/OAuthClientPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/OAuthClientPort.java
@@ -1,7 +1,10 @@
 package com.booquest.booquest_api.application.port.out.auth;
 
 import com.booquest.booquest_api.domain.user.model.SocialUser;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.proc.BadJOSEException;
+import java.text.ParseException;
 
 public interface OAuthClientPort {
-    SocialUser fetchUserInfo(String accessToken);
+    SocialUser fetchUserInfo(String accessToken) throws JOSEException, ParseException, BadJOSEException;
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/SocialUnlinkPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/SocialUnlinkPort.java
@@ -6,4 +6,6 @@ import jakarta.annotation.Nullable;
 public interface SocialUnlinkPort {
     // providerAccessToken: NAVER 필수, KAKAO는 null 가능
     boolean unlink(AuthProvider provider, String providerUserId, @Nullable String providerAccessToken);
+
+    boolean unlinkApple(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/TokenRepositoryPort.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/out/auth/TokenRepositoryPort.java
@@ -1,5 +1,6 @@
 package com.booquest.booquest_api.application.port.out.auth;
 
+import com.booquest.booquest_api.domain.auth.model.AppleRefreshToken;
 import com.booquest.booquest_api.domain.auth.model.Token;
 
 import java.time.LocalDateTime;
@@ -17,4 +18,8 @@ public interface TokenRepositoryPort {
     int deleteByRefreshTokenHash(String refreshTokenHash);
 
     int upsertByUserId(Long userId, String refreshTokenHash, LocalDateTime expiresAt);
+
+    void saveAppleRefreshToken(AppleRefreshToken appleRefreshToken);
+
+    Optional<String> findRefreshTokenByUserId(Long userId);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/auth/SocialLoginService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/auth/SocialLoginService.java
@@ -1,6 +1,7 @@
 package com.booquest.booquest_api.application.service.auth;
 
 import com.booquest.booquest_api.adapter.in.auth.web.dto.SocialLoginResponse;
+import com.booquest.booquest_api.adapter.out.auth.oauth.AppleOAuthClient;
 import com.booquest.booquest_api.adapter.out.auth.oauth.KakaoOAuthClient;
 import com.booquest.booquest_api.adapter.out.auth.oauth.NaverOAuthClient;
 import com.booquest.booquest_api.application.port.in.auth.SocialLoginUseCase;
@@ -26,6 +27,7 @@ public class SocialLoginService implements SocialLoginUseCase {
 //    private final OAuthClientPort oAuthClient;
     private final KakaoOAuthClient kakaoOAuthClient;
     private final NaverOAuthClient naverOAuthClient;
+    private final AppleOAuthClient appleOAuthClient;
     private final UserQueryPort userQueryPort; // User 정보 확인용
     private final TokenService tokenService;
     private final UserCommandPort userCommandPort;
@@ -52,8 +54,8 @@ public class SocialLoginService implements SocialLoginUseCase {
         return switch (provider) {
             case KAKAO -> kakaoOAuthClient.fetchUserInfo(accessToken);
             case NAVER -> naverOAuthClient.fetchUserInfo(accessToken);
+            case APPLE -> appleOAuthClient.fetchUserInfo(accessToken);
             // case GOOGLE -> googleOAuthClient.fetchUserInfo(accessToken);
-            // case APPLE  -> appleOAuthClient.fetchUserInfo(accessToken);
             default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
         };
     }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/auth/model/AppleRefreshToken.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/auth/model/AppleRefreshToken.java
@@ -1,0 +1,35 @@
+package com.booquest.booquest_api.domain.auth.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "apple_refresh_token")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AppleRefreshToken {
+
+    @Id
+    private Long userId;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String refreshToken;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Builder
+    public AppleRefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+        this.issuedAt = LocalDateTime.now();
+    }
+
+}

--- a/booquest-api/src/main/java/com/booquest/booquest_api/domain/user/model/SocialUser.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/domain/user/model/SocialUser.java
@@ -14,4 +14,5 @@ public class SocialUser {
     private final AuthProvider provider; // e.g., KAKAO, GOOGLE
     private final String providerId;
     private final String profileImageUrl;
+    private final String refreshToken;
 }

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -67,7 +67,7 @@ apple:
   auth:
     issuer: https://appleid.apple.com
     jwks-uri: https://appleid.apple.com/auth/keys
-    audience: com.your.bundle.id  # 실제 앱의 번들 ID로 교체
+    audience: com.booquest.app  # 앱의 번들 ID
     client-id: ${APPLE_CLIENT_ID}  # 서비스 ID
     team-id: ${APPLE_TEAM_ID}  # Apple Developer Team ID
     key-id: ${APPLE_KEY_ID}  # AuthKey_XXXXXX.p8의 키 ID

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -68,7 +68,17 @@ apple:
     issuer: https://appleid.apple.com
     jwks-uri: https://appleid.apple.com/auth/keys
     audience: com.your.bundle.id  # 실제 앱의 번들 ID로 교체
-    client-id: ${APPLE_CLIENT_ID}  # 앱에서 발급받은 서비스 ID (optional)
+    client-id: ${APPLE_CLIENT_ID}  # 서비스 ID
+    team-id: ${APPLE_TEAM_ID}  # Apple Developer Team ID
+    key-id: ${APPLE_KEY_ID}  # AuthKey_XXXXXX.p8의 키 ID
+    private-key: |
+      -----BEGIN PRIVATE KEY-----
+      ${APPLE_PRIVATE_KEY}
+      -----END PRIVATE KEY-----
+    revoke-url: https://appleid.apple.com/auth/revoke
+    timeout-ms: 4000
+    retry:
+      max-attempts: 1
 
 oauth:
   kakao:

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -63,6 +63,13 @@ naver:
   api:
     user-info-url: https://openapi.naver.com/v1/nid/me
 
+apple:
+  auth:
+    issuer: https://appleid.apple.com
+    jwks-uri: https://appleid.apple.com/auth/keys
+    audience: com.your.bundle.id  # 실제 앱의 번들 ID로 교체
+    client-id: ${APPLE_CLIENT_ID}  # 앱에서 발급받은 서비스 ID (optional)
+
 oauth:
   kakao:
     admin-key: ${KAKAO_ADMIN_KEY}

--- a/booquest-api/src/main/resources/application.yml
+++ b/booquest-api/src/main/resources/application.yml
@@ -71,10 +71,7 @@ apple:
     client-id: ${APPLE_CLIENT_ID}  # 서비스 ID
     team-id: ${APPLE_TEAM_ID}  # Apple Developer Team ID
     key-id: ${APPLE_KEY_ID}  # AuthKey_XXXXXX.p8의 키 ID
-    private-key: |
-      -----BEGIN PRIVATE KEY-----
-      ${APPLE_PRIVATE_KEY}
-      -----END PRIVATE KEY-----
+    private-key: ${APPLE_PRIVATE_KEY}
     revoke-url: https://appleid.apple.com/auth/revoke
     timeout-ms: 4000
     retry:

--- a/booquest-api/src/main/resources/db/migration/V15__create_apple_refresh_token_table.sql
+++ b/booquest-api/src/main/resources/db/migration/V15__create_apple_refresh_token_table.sql
@@ -1,0 +1,8 @@
+-- Apple refresh_token 등을 저장할 user_oauth_token 테이블 생성
+CREATE TABLE apple_refresh_token (
+                                  user_id BIGINT NOT NULL,
+                                  refresh_token TEXT,
+                                  issued_at TIMESTAMP WITHOUT TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+                                  PRIMARY KEY (user_id),
+                                  CONSTRAINT fk_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 애플 로그인 기능
- 애플 회원탈퇴 기능


## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #83 

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 애플 로그인은 리소스 서버에 요청하는 것이 아닌 id_token내부에 데이터가 전부 들어감
- 토큰 디코딩해서 데이터 추출 후 저장
- 회원 탈퇴시 애플 refresh token이 필요해 refresh token을 얻기 위한 요청 진행
- 해당 토큰은 TTL이 없어 테이블에 저장 후 회원 탈퇴시 사용
- 회원 탈퇴시 revoke api를 호출하여야 함

- application.yml의 APPLE_TEAM_ID, APPLE_KEY_ID, Key ID APPLE_PRIVATE_KEY는 영인님께 받아야 합니다
- APPLE_CLIENT_ID=com.booquest.app

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [ ] 코드가 정상 동작함
- [ ] 테스트를 모두 통과함
- [ ] 문서/주석이 적절히 작성됨
- [ ] Self Review 완료함
