### PR TITLE
[Feature] 캘린더 조회 시 imagePresignedUrl 반환

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/DailyRecordController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/DailyRecordController.java
@@ -59,7 +59,7 @@ public class DailyRecordController {
         CalendarRecordResponse response = getCalendarRecordsUseCase.getCalendarRecords(userId, year, month);
         
         List<CalendarDayRecord> dayRecords = response.getRecords().stream()
-            .map(record -> new CalendarDayRecord(record.getDay(), record.isHasRecord(), record.getImageUrl(), record.isXpGranted()))
+            .map(record -> new CalendarDayRecord(record.getDay(), record.isHasRecord(), record.getImagePresignedUrl(), record.isXpGranted()))
             .toList();
         
         CalendarRecordResponse calendarRecordResponse = new CalendarRecordResponse(

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/dto/CalendarDayRecord.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/dto/CalendarDayRecord.java
@@ -13,8 +13,8 @@ public class CalendarDayRecord {
     @Schema(description = "기록 존재 여부")
     private final boolean hasRecord;
 
-    @Schema(description = "기록 이미지 미리보기 URL (없을 수도 있음)")
-    private final String imageUrl;
+    @Schema(description = "이미지 조회용 presigned URL (없을 수도 있음)")
+    private final String imagePresignedUrl;
 
     @Schema(description = "XP 지급 여부")
     private final boolean xpGranted;

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/record/GetCalendarRecordsService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/record/GetCalendarRecordsService.java
@@ -3,6 +3,7 @@ package com.booquest.booquest_api.application.service.record;
 import com.booquest.booquest_api.adapter.in.record.web.dto.CalendarDayRecord;
 import com.booquest.booquest_api.adapter.in.record.web.dto.CalendarRecordResponse;
 import com.booquest.booquest_api.application.port.in.record.GetCalendarRecordsUseCase;
+import com.booquest.booquest_api.application.port.in.storage.ImageStoragePort;
 import com.booquest.booquest_api.application.port.out.record.DailyRecordRepositoryPort;
 import com.booquest.booquest_api.domain.record.model.DailyRecord;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -23,6 +26,10 @@ import java.util.stream.Collectors;
 @Transactional
 public class GetCalendarRecordsService implements GetCalendarRecordsUseCase {
     private final DailyRecordRepositoryPort dailyRecordRepository;
+    private final ImageStoragePort imageStoragePort;
+
+    private static final Duration PRESIGNED_TTL = Duration.ofMinutes(10);
+    private static final Duration RENEW_THRESHOLD = Duration.ofSeconds(30);
 
     @Override
     @Transactional(readOnly = true)
@@ -38,17 +45,48 @@ public class GetCalendarRecordsService implements GetCalendarRecordsUseCase {
                 .collect(Collectors.toMap(DailyRecord::getRecordDate, r -> r));
 
         List<CalendarDayRecord> days = new ArrayList<>(yearMonth.lengthOfMonth());
+        Instant now = Instant.now();
+
         for (int day = 1; day <= yearMonth.lengthOfMonth(); day++) {
             LocalDate date = yearMonth.atDay(day);
             DailyRecord rec = byDate.get(date);
 
             boolean hasRecord = rec != null;
             boolean xpGranted = rec != null && rec.isXpGranted();
-            String imageUrl   = rec != null ? rec.getImageObjectKey() : null;
+            String presignedUrl = null;
 
-            days.add(new CalendarDayRecord(day, hasRecord, imageUrl, xpGranted));
+            if (rec != null && rec.getImageObjectKey() != null) {
+                // presigned가 유효한지 확인
+                boolean needRenew = needRenew(rec.getImagePresignedUrl(), rec.getImagePresignedExpiresAt(), now);
+
+                if (needRenew) {
+                    // 새로 발급
+                    String newUrl = imageStoragePort.createPresignedGetUrl(rec.getImageObjectKey(), PRESIGNED_TTL);
+                    Instant expiresAt = now.plus(PRESIGNED_TTL);
+
+                    // 엔티티에 반영
+                    rec.refreshImagePresigned(newUrl, expiresAt);
+                    // 캘린더지만, presigned를 다시 저장해줘야 다음 요청에서도 그대로 씀
+                    dailyRecordRepository.save(rec);
+
+                    presignedUrl = newUrl;
+                } else {
+                    presignedUrl = rec.getImagePresignedUrl();
+                }
+            }
+
+            days.add(new CalendarDayRecord(day, hasRecord, presignedUrl, xpGranted));
         }
 
         return new CalendarRecordResponse(year, month, days);
+    }
+
+    private boolean needRenew(String presignedUrl, Instant expiresAt, Instant now) {
+        if (presignedUrl == null || expiresAt == null) {
+            return true;
+        }
+        // 만료되었거나 (expiresAt <= now) / 남은 시간이 30초 미만이면 재발급
+        Instant threshold = now.plus(RENEW_THRESHOLD);
+        return expiresAt.isBefore(threshold);
     }
 }


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
캘린더 조회 시 imagePresignedUrl 반환

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 캘린더 조회 시 imagePresignedUrl 반환
- 
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #100 

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 응답값에서 imageUrl 필드 삭제
- 응답값에 imagePresignedUrl 필드 추가

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [x] 테스트를 모두 통과함
- [x] 문서/주석이 적절히 작성됨
- [x] Self Review 완료함
