### PR TITLE
[Feature] 오늘의 부업 활동 기록 생성 시 날짜 선택 기능 추가

### DIFF
--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/DailyRecordController.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/DailyRecordController.java
@@ -41,11 +41,18 @@ public class DailyRecordController {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "오늘의 부업 활동 기록 생성",
-            description = "텍스트와 이미지 URL로 오늘의 부업 활동을 기록하고 경험치 5XP를 지급받습니다. 해당 경험치는 하루 1회만 받을 수 있습니다.")
+            description = "텍스트와 이미지로 부업 활동을 기록하고 경험치 5XP를 지급받습니다. 해당 경험치는 하루 1회만 받을 수 있습니다.</br></br>" +
+                    "- recordDate 파라미터를 제공하면 해당 날짜의 기록을 생성합니다. (날짜 형식: yyyy-MM-dd)</br>" +
+                    "- recordDate 파라미터가 null이면 오늘 날짜로 기록을 생성합니다.</br></br></br>" +
+                    "--- Swagger 이용 시 ---</br>" +
+                    "- 이미지를 업로드하지 않을 경우, </br>" +
+                    "&nbsp;&nbsp;&nbsp;file 필드는 'No file chosen' 상태로 두고 'Send empty value'는 체크 해제하고 요청을 보내면 됩니다. " +
+                    "('Send empty value'를 체크할 경우 빈 문자열이 전송되어 오류 발생)</br>" +
+                    "- content 및 recordDate는 'Send empty value' 옵션을 사용해도 무방합니다.")
     public ApiResponse<DailyRecordResponse> createRecord(@Valid @ModelAttribute CreateRecordRequest request) {
         Long userId = getUserId();
 
-        DailyRecordResponse response = createRecordUseCase.createRecord(userId, request.getContent(), request.getFile());
+        DailyRecordResponse response = createRecordUseCase.createRecord(userId, request.getContent(), request.getFile(), request.getRecordDate());
         String message = response.isXpGranted() ? "부업 활동 기록이 저장되고 경험치 5XP가 지급되었습니다." : "부업 활동 기록이 저장되었습니다.";
 
         return ApiResponse.success(message, response);
@@ -73,8 +80,7 @@ public class DailyRecordController {
 
     @GetMapping("/date/{date}")
     @Operation(summary = "오늘의 부업 활동 기록 상세 조회 (날짜 조회)",
-               description = "지정된 날짜의 기록을 조회합니다. 기록이 없으면 빈 응답을 반환합니다.</br></br>" +
-                       "Date 형식: 2025-10-30")
+               description = "지정된 날짜의 기록을 조회합니다. 기록이 없으면 빈 응답을 반환합니다. (날짜 형식: yyyy-MM-dd)</br></br>")
     public ApiResponse<DailyRecordResponse> getRecordByDate(@PathVariable LocalDate date) {
         Long userId = getUserId();
         DailyRecordResponse response = getRecordUseCase.getRecordByDate(userId, date);
@@ -84,11 +90,10 @@ public class DailyRecordController {
 
     @PutMapping(value = "/{recordId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "오늘의 부업 활동 기록 수정",
-            description = "부업 활동 기록을 수정합니다.</br>" +
+            description = "부업 활동 기록을 수정합니다. 경험치는 더이상 지급되지 않습니다.</br></br>" +
                     "- content만 보내면 내용만 수정되고 기존 이미지는 그대로 둡니다.</br>" +
                     "- file을 업로드하면 기존 이미지는 삭제되고 새 이미지로 교체됩니다. (removeImage=false 여야 함)</br>" +
-                    "- removeImage=true 를 보내면 기존 이미지를 삭제합니다. (file과 상관없이)</br>" +
-                    "경험치는 더이상 지급되지 않습니다.")
+                    "- removeImage=true 를 보내면 기존 이미지를 삭제합니다. (file과 상관없이)</br>")
     public ApiResponse<UpdateRecordResponse> updateRecord(@PathVariable Long recordId, @Valid @ModelAttribute UpdateRecordRequest request) {
         Long userId = getUserId();
 
@@ -99,7 +104,7 @@ public class DailyRecordController {
 
     @DeleteMapping("/{recordId}")
     @Operation(summary = "오늘의 부업 활동 기록 삭제",
-            description = "부업 활동 기록을 삭제합니다.</br>" +
+            description = "부업 활동 기록을 삭제합니다.</br></br>" +
                     "- 이 기록이 생성될 때 5XP가 지급되었다면, 삭제 시 5XP가 회수됩니다.</br>" +
                     "- 기록에 이미지가 있으면 NCP Object Storage에서도 함께 삭제됩니다.")
     public ApiResponse<DeleteRecordResponse> deleteRecord(@PathVariable Long recordId) {

--- a/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/dto/CreateRecordRequest.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/adapter/in/record/web/dto/CreateRecordRequest.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+
 @AllArgsConstructor
 @Getter
 public class CreateRecordRequest {
@@ -13,6 +15,10 @@ public class CreateRecordRequest {
     @Size(max = 1000, message = "기록 내용은 1000자를 초과할 수 없습니다.")
     String content;
 
-    @Schema(description = "이미지 File")
+    @Schema(description = "이미지 File (선택사항). 이미지를 업로드하지 않을 경우 Swagger에서 'Send empty value'를 체크하지 마세요. \" +\n" +
+                            "\"파일이 없을 때는 file 필드를 아예 전송하지 않아야 정상 처리됩니다.")
     private MultipartFile file;
+
+    @Schema(description = "기록 날짜 (선택사항, null이면 오늘 날짜로 생성)", example = "2025-11-10")
+    private LocalDate recordDate;
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/record/CreateRecordUseCase.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/port/in/record/CreateRecordUseCase.java
@@ -3,6 +3,8 @@ package com.booquest.booquest_api.application.port.in.record;
 import com.booquest.booquest_api.adapter.in.record.web.dto.DailyRecordResponse;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDate;
+
 public interface CreateRecordUseCase {
-    DailyRecordResponse createRecord(Long userId, String content, MultipartFile file);
+    DailyRecordResponse createRecord(Long userId, String content, MultipartFile file, LocalDate recordDate);
 }

--- a/booquest-api/src/main/java/com/booquest/booquest_api/application/service/record/CreateRecordService.java
+++ b/booquest-api/src/main/java/com/booquest/booquest_api/application/service/record/CreateRecordService.java
@@ -34,18 +34,19 @@ public class CreateRecordService implements CreateRecordUseCase {
     private static final Duration PRESIGNED_TTL = Duration.ofMinutes(10);
 
     @Override
-    public DailyRecordResponse createRecord(Long userId, String content, MultipartFile file) {
-        LocalDate today = LocalDate.now();
+    public DailyRecordResponse createRecord(Long userId, String content, MultipartFile file, LocalDate recordDate) {
+        // 날짜가 null이면 오늘 날짜로 설정
+        LocalDate targetDate = recordDate != null ? recordDate : LocalDate.now();
 
         // 0) 입력 검증
         boolean hasContent = content != null && !content.isBlank();
-        boolean hasFile = file != null && !file.isEmpty();
+        boolean hasFile = file != null && !file.isEmpty() && !("".equals(file));
         if (!hasContent && !hasFile) {
             throw new IllegalArgumentException("내용 또는 이미지는 최소 하나 이상 있어야 합니다.");
         }
 
-        // 1) 오늘 기록 있는지 확인
-        dailyRecordRepository.findByUserIdAndRecordDate(userId, today)
+        // 1) 해당 날짜 기록 있는지 확인
+        dailyRecordRepository.findByUserIdAndRecordDate(userId, targetDate)
                 .ifPresent(r -> { throw DailyRecordAlreadyExistsException.with(r.getId(), r.getRecordDate()); });
 
         // 2) 파일 있으면 여기서 key 만들고 업로드
@@ -54,7 +55,7 @@ public class CreateRecordService implements CreateRecordUseCase {
         Instant presignedExpiresAt = null;
 
         if (hasFile) {
-            String datePart = today.format(DateTimeFormatter.BASIC_ISO_DATE); // ex. 20251031
+            String datePart = targetDate.format(DateTimeFormatter.BASIC_ISO_DATE); // ex. 20251031
             String ext = getExt(file.getOriginalFilename());
             String key = String.format("records/%d/%s/%s%s",
                     userId,
@@ -81,7 +82,7 @@ public class CreateRecordService implements CreateRecordUseCase {
         // 3) 엔티티 생성
         DailyRecord record = DailyRecord.builder()
                 .userId(userId)
-                .recordDate(today)
+                .recordDate(targetDate)
                 .content(content)
                 .imageObjectKey(objectKey)
                 .imagePresignedUrl(presignedUrl)


### PR DESCRIPTION
## 📌 PR 제목
<!-- 예: feat: 로그인 API 구현 -->
오늘의 부업 활동 기록 생성 시 날짜 선택 기능 추가

## ✅ 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약 -->
- 생성 API - 날짜 파라미터 추가
- 
- 

## 🔍 관련 이슈
<!-- 연결된 이슈가 있다면 -->
- Resolved: #100 

## 💡 추가 설명 (선택)
<!-- 코드 리뷰어가 이해하는 데 도움이 되는 정보, 참고자료 등 -->
- 
- 

## 📸 스크린샷 (UI 변경 시)
<!-- before / after 이미지 첨부 -->

## 📋 체크리스트
- [x] 코드가 정상 동작함
- [x] 테스트를 모두 통과함
- [x] 문서/주석이 적절히 작성됨
- [x] Self Review 완료함
